### PR TITLE
Fix for the Content Injection vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "koa-favicon": "^1.2.0",
     "koa-flash": "^1.0.0",
     "koa-fresh": "0.0.3",
-    "koa-hbs": "^0.8.1",
+    "koa-hbs": "^0.9.0",
     "koa-helmet": "^1.0.0",
     "koa-json": "^1.1.1",
     "koa-logger": "^1.2.2",


### PR DESCRIPTION
gbptm is currently affected by the high-severity [Content Injection vulnerability](https://snyk.io/vuln/npm:handlebars:20151207). 

Vulnerable module: `handlebars`
Introduced through: ` koa-hbs`

This PR fixes the Content Injection vulnerability by upgrading `koa-hbs` to version 0.9.0 This upgrade will also fix the following other vulnerabilities:
* [Improper minification of non-boolean comparisons vulnerabilty](https://snyk.io/vuln/npm:uglify-js:20150824) in the `uglify-js` dependency.
* [ReDOS vulnerability](https://snyk.io/vuln/npm:uglify-js:20151024) in the `uglify-js` dependency.

Check out the [Snyk test report](https://snyk.io/test/github/neontribe/gbptm) to review other vulnerabilities that affect this repo. 

[Watch the repo](https://snyk.io/add) to 
* get alerts if newly disclosed vulnerabilities affect this repo in the future. 
* generate pull requests with the fixes you want, or let us do the work: when a newly disclosed vulnerability affects you, we'll submit a fix to you right away. 

Stay secure, 
The Snyk team