### PR TITLE
CI Test Fix

### DIFF
--- a/packages/api/src/test/loo_routes.test.js
+++ b/packages/api/src/test/loo_routes.test.js
@@ -4,11 +4,14 @@ const Loo = require('../models/loo');
 const mongoose = require('mongoose');
 const looRadius = require('./data/looRadius.js');
 
+beforeAll(async () => {
+  await Loo.ensureIndexes();
+});
+
 describe('api loo routes (public)', () => {
   describe('/api/loos/near/:lon/:lat', () => {
     beforeAll(async () => {
       await Loo.collection.insertMany(looRadius);
-      await Loo.ensureIndexes();
     });
 
     it('should return a limit of 5 loos for -0.2068223/51.518342', async () => {
@@ -44,7 +47,6 @@ describe('api loo routes (public)', () => {
     const looBox = require('./data/looBox.js');
     beforeAll(async () => {
       await Loo.collection.insertMany(looBox);
-      await Loo.ensureIndexes();
     });
 
     it('should return 12 loos', async () => {

--- a/packages/api/src/test/loo_routes.test.js
+++ b/packages/api/src/test/loo_routes.test.js
@@ -8,6 +8,7 @@ describe('api loo routes (public)', () => {
   describe('/api/loos/near/:lon/:lat', () => {
     beforeAll(async () => {
       await Loo.collection.insertMany(looRadius);
+      await Loo.ensureIndexes();
     });
 
     it('should return a limit of 5 loos for -0.2068223/51.518342', async () => {
@@ -43,6 +44,7 @@ describe('api loo routes (public)', () => {
     const looBox = require('./data/looBox.js');
     beforeAll(async () => {
       await Loo.collection.insertMany(looBox);
+      await Loo.ensureIndexes();
     });
 
     it('should return 12 loos', async () => {


### PR DESCRIPTION
Previously, when tests were running in a scenario in which the `gbptm-test` database had not been created by previous testing, the tests would fail, with mongoose blaming a lack of geo indexes.

This could be reproduced locally, as well as in the CI environment, by dropping the `gbptm-test` database.

This fix ensures that these indexes have been created before tests are run, however, it is likely that this could be a symptom of a greater problem with how we are using mongoose's sometimes unpredictably ordered operations.