### PR TITLE
Query sanitisation

### DIFF
--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -7,6 +7,10 @@ require('./config/mongo'); // don't much like this bare require
 
 const app = express();
 
+// we can make some nicer assumptions about security if query values are only
+// ever strings, not arrays or objects
+app.set('query parser', 'simple');
+
 app.use(helmet());
 app.use(compression());
 

--- a/packages/api/src/models/loo.js
+++ b/packages/api/src/models/loo.js
@@ -11,9 +11,9 @@ looSchema.statics.findNear = function(lon, lat, maxDistance, limit) {
   return this.aggregate([
     {
       $geoNear: {
-        near: [parseFloat(lon), parseFloat(lat)],
+        near: [lon, lat],
         distanceField: 'distance',
-        maxDistance: parseFloat(maxDistance) / earth,
+        maxDistance: maxDistance / earth,
         limit: limit,
         distanceMultiplier: earth,
         spherical: true,
@@ -37,15 +37,7 @@ looSchema.statics.findIds = function(query) {
 looSchema.statics.findIn = function(sw, ne, nw, se) {
   var bbox = {
     type: 'Polygon',
-    coordinates: [
-      [
-        _.map(sw.split(','), parseFloat),
-        _.map(nw.split(','), parseFloat),
-        _.map(ne.split(','), parseFloat),
-        _.map(se.split(','), parseFloat),
-        _.map(sw.split(','), parseFloat),
-      ],
-    ],
+    coordinates: [[sw, nw, ne, se, sw]],
   };
   var swp = {
     type: 'Point',
@@ -58,7 +50,7 @@ looSchema.statics.findIn = function(sw, ne, nw, se) {
       $geoNear: {
         near: centre.coordinates,
         distanceField: 'distance',
-        maxDistance: parseFloat(maxDistance) / earth,
+        maxDistance: maxDistance / earth,
         distanceMultiplier: earth,
         spherical: true,
       },

--- a/packages/api/src/models/loo_schema.js
+++ b/packages/api/src/models/loo_schema.js
@@ -100,4 +100,10 @@ schemae.looSchema.index({ geometry: '2dsphere' });
 schemae.looSchema.index({ geohash: 1 });
 schemae.looSchema.plugin(mongoosePaginate);
 
+// add text index for search API endpoint
+schemae.looSchema.index(
+  { 'properties.name': 'text', 'properties.notes': 'text' },
+  { default_language: 'none' }
+);
+
 module.exports = schemae;

--- a/packages/api/src/routes/public/loo.js
+++ b/packages/api/src/routes/public/loo.js
@@ -9,11 +9,12 @@ const config = require('../../config/config');
  * Accepts `radius` in meters in query
  */
 router.get('/near/:lon/:lat', async (req, res) => {
-  const maxDistance = req.query.radius || config.query_defaults.maxDistance;
-  const limit = req.query.limit || config.query_defaults.limit;
+  const maxDistance =
+    parseFloat(req.query.radius) || config.query_defaults.maxDistance;
+  const limit = parseFloat(req.query.limit) || config.query_defaults.limit;
   const loos = await Loo.findNear(
-    req.params.lon,
-    req.params.lat,
+    parseFloat(req.params.lon),
+    parseFloat(req.params.lat),
     maxDistance,
     limit
   ).exec();
@@ -25,10 +26,10 @@ router.get('/near/:lon/:lat', async (req, res) => {
  */
 router.get('/in/:sw/:ne/:nw/:se', async (req, res) => {
   const loos = await Loo.findIn(
-    req.params.sw,
-    req.params.ne,
-    req.params.nw,
-    req.params.se
+    req.params.sw.split(',').map(parseFloat),
+    req.params.ne.split(',').map(parseFloat),
+    req.params.nw.split(',').map(parseFloat),
+    req.params.se.split(',').map(parseFloat)
   ).exec();
   res.status(200).json(new LooList(loos));
 });

--- a/packages/api/src/routes/public/search.js
+++ b/packages/api/src/routes/public/search.js
@@ -13,26 +13,12 @@ router.get('/', async (req, res) => {
   delete params.page;
 
   if (params.text) {
-    query.$or = [
-      { 'properties.name': new RegExp('.*' + req.query.text + '.*', 'i') },
-      { 'properties.notes': new RegExp('.*' + req.query.text + '.*', 'i') },
-    ];
+    query.$or = [{ $text: { $search: req.query.text } }];
   }
   delete params.text;
 
-  // Handle text searches
-  _.each(params, function(val, name) {
-    query.$and = query.$and || [];
-    if (/^text_/.test(name)) {
-      query.$and.push({
-        ['properties.' + name.replace('text_', '')]: new RegExp(
-          '.*' + val + '.*',
-          'i'
-        ),
-      });
-      delete params[name];
-    }
-  });
+  // Arbitrary text searches have been removed until a way is found that is not
+  // prone to ReDoS attacks or indexing every possible property by text
 
   // Handle queries for missing fields
   _.each(params, function(val, name) {

--- a/packages/api/src/routes/public/search.js
+++ b/packages/api/src/routes/public/search.js
@@ -7,8 +7,8 @@ router.get('/', async (req, res) => {
   const params = Object.assign({}, req.query);
   const query = {};
   // Strip out the pagination we use
-  const limit = params.limit || 10;
-  const page = params.page || 1;
+  const limit = parseInt(params.limit) || 10;
+  const page = parseInt(params.page) || 1;
   delete params.limit;
   delete params.page;
 


### PR DESCRIPTION
* Fixes the family of exploits described in f7de9b5
* Generally attempts to interpret query and parameter values as soon as possible to avoid similar issues and tidy the code a little

I'm unsure as to whether tests should be made to check for this particular exploit. Although it would be nice to know one exploit we're safe from, it would be a very specific test and it might be sufficient instead to simply test that strange parameters and queries are handled properly when properly covering the `api` package with tests.