### PR TITLE
fix: describe add/edit page appropriately

### DIFF
--- a/packages/ui/src/pages/AddEditPage.js
+++ b/packages/ui/src/pages/AddEditPage.js
@@ -209,7 +209,11 @@ class AddEditPage extends Component {
           </div>
         </div>
 
-        <h2 className={headings.large}>Add This Loo</h2>
+        {this.props.loo ? (
+          <h2 className={headings.large}>Edit This Loo</h2>
+        ) : (
+          <h2 className={headings.large}>Add This Loo</h2>
+        )}
 
         <MediaQuery maxWidth={config.viewport.mobile}>
           {this.renderMobileMap()}

--- a/packages/ui/src/pages/AddEditPage.js
+++ b/packages/ui/src/pages/AddEditPage.js
@@ -210,7 +210,7 @@ class AddEditPage extends Component {
         </div>
 
         {this.props.loo ? (
-          <h2 className={headings.large}>Edit This Loo</h2>
+          <h2 className={headings.large}>Update This Loo</h2>
         ) : (
           <h2 className={headings.large}>Add This Loo</h2>
         )}


### PR DESCRIPTION
See #200.

This can be extended to more of the form's description if necessary, else this should be ready for merging.