### PR TITLE
fix: adjust z-index so crosshair is visible

### DIFF
--- a/packages/ui/src/components/css/edit-loo-map.module.css
+++ b/packages/ui/src/components/css/edit-loo-map.module.css
@@ -16,7 +16,7 @@
 	margin-top: -20px;
 	margin-left: -1px;
 	background: rgba(0, 0, 0, 0.8);
-	z-index: 2;
+	z-index: 1002;
 }
 
 .map::after {
@@ -30,5 +30,5 @@
 	margin-top: -1px;
 	margin-left: -20px;
 	background: rgba(0, 0, 0, 0.8);
-	z-index: 2;
+	z-index: 1002;
 }


### PR DESCRIPTION
closes #180 

This was fixed just be bumping up the z-index.

Alternative solutions considered:
* **Using leaflet's API to add a new layer/pane** - leaflet doesn't provide any abstraction beyond dealing with z-indexes through its API if one wishes to guarantee how its elements stack, so this would've required JavaScript and increased the complexity of the solution dramatically
* **Using relative z-indexes and clever CSS to always ensure the crosshair is higher than the map's container** - I couldn't find a way to give a stacking context in the parent node of the map without changing visible CSS properties undesirably; maybe somebody better at CSS could work out how to do this?

The current solution should suffice unless we find this to be a regular issue on updating our leaflet dependency.