### PR TITLE
Nearby Loo Improvements

### DIFF
--- a/packages/api/src/config/config.js
+++ b/packages/api/src/config/config.js
@@ -29,8 +29,8 @@ var base = {
       'mongodb://localhost:27017/gbptm',
   },
   query_defaults: {
-    maxDistance: 50000,
-    limit: 5,
+    defaultRadius: 5000,
+    maxRadius: 50000,
   },
   deduplication: {
     radius: 25,

--- a/packages/api/src/models/loo.js
+++ b/packages/api/src/models/loo.js
@@ -14,6 +14,7 @@ looSchema.statics.findNear = function(lon, lat, radius) {
         distanceField: 'distance',
         maxDistance: radius,
         spherical: true,
+        limit: 2 ** 62, // infeasibly large number
       },
     },
     {

--- a/packages/api/src/models/loo.js
+++ b/packages/api/src/models/loo.js
@@ -3,7 +3,7 @@ const looSchema = require('./loo_schema').looSchema;
 const _ = require('lodash');
 var Loo;
 
-looSchema.statics.findNear = function(lon, lat, maxDistance, limit) {
+looSchema.statics.findNear = function(lon, lat, radius) {
   return this.aggregate([
     {
       $geoNear: {
@@ -12,8 +12,7 @@ looSchema.statics.findNear = function(lon, lat, maxDistance, limit) {
           coordinates: [lon, lat],
         },
         distanceField: 'distance',
-        maxDistance: maxDistance,
-        limit: limit,
+        maxDistance: radius,
         spherical: true,
       },
     },

--- a/packages/api/src/models/loo.js
+++ b/packages/api/src/models/loo.js
@@ -1,18 +1,19 @@
 const mongoose = require('mongoose');
 const looSchema = require('./loo_schema').looSchema;
 const _ = require('lodash');
-const earth = 6731000;
 var Loo;
 
 looSchema.statics.findNear = function(lon, lat, maxDistance, limit) {
   return this.aggregate([
     {
       $geoNear: {
-        near: [lon, lat],
+        near: {
+          type: 'Point',
+          coordinates: [lon, lat],
+        },
         distanceField: 'distance',
-        maxDistance: maxDistance / earth,
+        maxDistance: maxDistance,
         limit: limit,
-        distanceMultiplier: earth,
         spherical: true,
       },
     },

--- a/packages/api/src/routes/loos.js
+++ b/packages/api/src/routes/loos.js
@@ -9,14 +9,13 @@ const config = require('../config/config');
  * Accepts `radius` in meters in query
  */
 router.get('/near/:lon/:lat', async (req, res) => {
-  const maxDistance =
-    parseFloat(req.query.radius) || config.query_defaults.maxDistance;
-  const limit = parseFloat(req.query.limit) || config.query_defaults.limit;
+  const wantedRadius =
+    parseFloat(req.query.radius) || config.query_defaults.defaultRadius;
+  const allowedRadius = Math.min(wantedRadius, config.query_defaults.maxRadius);
   const loos = await Loo.findNear(
     parseFloat(req.params.lon),
     parseFloat(req.params.lat),
-    maxDistance,
-    limit
+    allowedRadius
   ).exec();
   res.status(200).json(new LooList(loos));
 });

--- a/packages/api/src/test/loo_routes.test.js
+++ b/packages/api/src/test/loo_routes.test.js
@@ -14,23 +14,23 @@ describe('api loo routes (public)', () => {
       await Loo.collection.insertMany(looRadius);
     });
 
-    it('should return a limit of 5 loos for -0.2068223/51.518342', async () => {
+    it('should return 20 loos for -0.2068223/51.518342, default radius', async () => {
       const response = await request(app).get(
         '/api/loos/near/-0.2068223/51.518342/'
-      );
-      expect(response.statusCode).toBe(200);
-      expect(response.body.features.length).toBe(5);
-    });
-
-    it('should return 20 loos for -0.2068223/51.518342', async () => {
-      const response = await request(app).get(
-        '/api/loos/near/-0.2068223/51.518342/?limit=20'
       );
       expect(response.statusCode).toBe(200);
       expect(response.body.features.length).toBe(20);
     });
 
-    it('should return 0 loos for 51.518342/-0.2068223', async () => {
+    it('should return 8 loos for -0.2068223/51.518342, 1km radius', async () => {
+      const response = await request(app).get(
+        '/api/loos/near/-0.2068223/51.518342/?radius=1000'
+      );
+      expect(response.statusCode).toBe(200);
+      expect(response.body.features.length).toBe(8);
+    });
+
+    it('should return 0 loos for 51.518342/-0.2068223, default radius', async () => {
       const response = await request(app).get(
         '/api/loos/near/51.518342/-0.2068223'
       );

--- a/packages/ui/src/api.js
+++ b/packages/ui/src/api.js
@@ -6,9 +6,8 @@ import config, { PREFERENCES_KEY } from './config';
 
 const api = {};
 
-api.findLoos = async function(lng, lat, { limit, radius } = config.nearest) {
-  // Todo: Fix the api to avoid this hard limit
-  const qs = querystring.stringify({ limit: 1000, radius });
+api.findLoos = async function(lng, lat, radius) {
+  const qs = querystring.stringify({ radius });
   const url = `${config.apiEndpoint}/loos/near/${lng}/${lat}?${qs}`;
   const res = await fetch(url, {
     headers: {

--- a/packages/ui/src/components/map/LooMap.js
+++ b/packages/ui/src/components/map/LooMap.js
@@ -144,12 +144,8 @@ export class LooMap extends Component {
     var map = this.leafletElement;
     var center = map.getCenter();
 
-    // Calculate radius
-    var mapBoundNorthEast = map.getBounds().getNorthEast();
-    var radius = mapBoundNorthEast.distanceTo(map.getCenter());
-
     this.props.onUpdateCenter(center);
-    this.props.onMove(center.lng, center.lat, radius);
+    this.props.onMove(center.lng, center.lat);
   }
 
   onZoom(event) {

--- a/packages/ui/src/components/map/NearestLooMap.js
+++ b/packages/ui/src/components/map/NearestLooMap.js
@@ -9,10 +9,11 @@ import {
   actionZoom,
   actionUpdateCenter,
 } from '../../redux/modules/mapControls';
-
 import { actionFindNearbyRequest } from '../../redux/modules/loos';
 
 import styles from '../css/loo-map.module.css';
+
+import config from '../../config';
 
 class NearestLooMap extends Component {
   constructor(props) {
@@ -20,9 +21,9 @@ class NearestLooMap extends Component {
     this.onMove = this.onMove.bind(this);
   }
 
-  onMove(lng, lat, radius) {
+  onMove(lng, lat) {
     this.props.actionUpdateCenter({ lat, lng });
-    this.props.actionFindNearbyRequest(lng, lat, radius);
+    this.props.actionFindNearbyRequest(lng, lat, config.nearestRadius);
   }
 
   render() {

--- a/packages/ui/src/config.js
+++ b/packages/ui/src/config.js
@@ -7,10 +7,8 @@ export default {
     mobile: 567,
   },
   apiEndpoint: '/api',
-  nearest: {
-    limit: 5,
-    radius: 5000, // meters
-  },
+  nearestRadius: 50000, // meters
+  nearestListLimit: 5,
   initialZoom: 16,
   minZoom: 12,
   maxZoom: 18,

--- a/packages/ui/src/pages/HomePage.js
+++ b/packages/ui/src/pages/HomePage.js
@@ -39,7 +39,7 @@ export class HomePage extends Component {
       this.props.actionFindNearbyRequest(
         position.lng,
         position.lat,
-        config.nearest.radius
+        config.nearestRadius
       );
     }
   }
@@ -60,7 +60,7 @@ export class HomePage extends Component {
     if (loos && !loos.length) {
       return (
         <Notification>
-          <p>No nearby loos found.</p>
+          <p>No loos found within {config.nearestRadius / 1000}km.</p>
         </Notification>
       );
     }
@@ -70,7 +70,7 @@ export class HomePage extends Component {
         <h2 className={headings.large}>Nearest Toilets</h2>
         <ul className={styles.looList}>
           {loos &&
-            loos.slice(0, config.nearest.limit).map((loo, i) => (
+            loos.slice(0, config.nearestListLimit).map((loo, i) => (
               <li key={i} className={styles.looListItem}>
                 <LooListItem
                   loo={loo}
@@ -103,7 +103,7 @@ export class HomePage extends Component {
   renderWelcome() {
     var content = `
             <p>The ${
-              config.nearest.limit
+              config.nearestListLimit
             } nearest toilets are listed below. Click more info to find out about
             each toilet's features.</p><p>You can set preferences to highlight toilets that meet your specific
             needs.</p>


### PR DESCRIPTION
closes #185

The quantity limit has been removed and so this is no longer an issue. Nearby loos are now only limited by distance, which has been given a maximum and a modest default within the API.

closes #186

Our current API function [deconstructs its limit arguments](https://github.com/neontribe/gbptm/blob/3277b5d6dc95833db70303d94fd15c1c54b09391/packages/ui/src/api.js#L8) but, despite this, everywhere it is called [we are passing a single number instead of an object](https://github.com/neontribe/gbptm/blob/3277b5d6dc95833db70303d94fd15c1c54b09391/packages/ui/src/redux/sagas/loos.js#L24). This was leading us to have both limit and radius as undefined within the function, hitting the API endpoint with an empty query value for limit and hence falling back on what was then the default of 50km.

This behaviour has been made explicit, with the interface also being more clear that if no nearby loos are found, it is because there are none within 50km. This is because, although unintended, this method was working satisfactorily and our code for adjusting the radius relative to our viewport size was a little unsafe in that it was not guaranteed to achieve full coverage with the map projection that most online maps use.

We have a naive approach, as a new query will be issued following every movement, even if the map's viewport has not left the bounds searched in the previous query. I will make a low-priority issue to improve on this, as caching here would lead to significant performance improvements.