### PR TITLE
Moving a loo too far duplicates it

### DIFF
--- a/packages/api/src/models/loo.js
+++ b/packages/api/src/models/loo.js
@@ -116,6 +116,8 @@ looSchema.methods.regenerate = async function() {
   geometry.coordinates[1] =
     recentLooReports[recentLooReports.length - 1].geometry.coordinates[1];
 
+  loo.geometry = geometry;
+
   /*
   //Skewed average based on trust
   geometry.coordinates[0] = _.meanBy(loo.reports, function(report) { return report.geometry.coordinates[0]*report.trust;})/_.sumBy(trustedLooReports,'trust');

--- a/packages/ui/src/pages/AddEditPage.js
+++ b/packages/ui/src/pages/AddEditPage.js
@@ -129,7 +129,7 @@ class AddEditPage extends Component {
     };
 
     // Keep only new or changed data, by comparing to the form's initial state
-    const changes = onlyChanges(before, now);
+    const changes = onlyChanges(now, before);
 
     if (!this.isDerived()) {
       // If we're a new loo, we always want geometry, regardless of whether it
@@ -157,15 +157,22 @@ class AddEditPage extends Component {
     const changes = this.getNovelInput();
 
     // Only submit if we've got something to tell
-    if (!_.isEmpty(changes)) {
-      // Always associate geometry with a report, even if unchanged
-      changes.geometry = {
-        type: 'Point',
-        coordinates: [this.getCenter().lng, this.getCenter().lat],
-      };
-
-      this.props.actionReportRequest(changes);
+    if (_.isEmpty(changes)) {
+      return;
     }
+
+    // Always associate geometry with a report, even if unchanged
+    changes.geometry = {
+      type: 'Point',
+      coordinates: [this.getCenter().lng, this.getCenter().lat],
+    };
+
+    // Show that this report is a derivation of a previous loo
+    if (this.isDerived()) {
+      changes.derivedFrom = this.props.loo._id;
+    }
+
+    this.props.actionReportRequest(changes);
   }
 
   renderMobileMap() {


### PR DESCRIPTION
closes #224

Fixed a number of bugs here:
* When regenerating a loo from its reports, the latest geometry was found [but not used to replace the existing geometry](https://github.com/neontribe/gbptm/compare/moving-duplicate?expand=1#diff-b7c5fc8aec753bf09eac5e21f01f078cR119)
* While reports had been slimmed down, [we were still sending the old values](https://github.com/neontribe/gbptm/compare/moving-duplicate?expand=1#diff-042b23d2cad108ca540ba50cc64cfae1L132)
* We had [stopped citing the reports we had derived new reports from](https://github.com/neontribe/gbptm/compare/moving-duplicate?expand=1#diff-042b23d2cad108ca540ba50cc64cfae1R170) following slimming reports down

All in all, when loos are moved now, they should actually be moved. Editing their properties should now also work as expected.