### PR TITLE
Loo prop humanization

### DIFF
--- a/packages/ui/src/config.js
+++ b/packages/ui/src/config.js
@@ -17,50 +17,53 @@ export default {
   allowAddEditLoo: true,
   showBackButtons: false,
   looProps: {
-    opening: definitions,
-    type: [
-      {
-        name: 'Female',
-        value: 'female',
-      },
-      {
-        name: 'Male',
-        value: 'male',
-      },
-      {
-        name: 'Female and Male',
-        value: 'female and male',
-      },
-      {
-        name: 'Unisex',
-        value: 'unisex',
-      },
-      {
-        name: 'Male Urinal',
-        value: 'male urinal',
-      },
-      {
-        name: 'Children Only',
-        value: 'children only',
-      },
-      {
-        name: 'None',
-        value: 'none',
-      },
-    ],
-    access: [
-      {
-        name: 'Public',
-        value: 'public',
-      },
-      {
-        name: 'Non-customers permitted',
-        value: 'permissive',
-      },
-      {
-        name: 'Customers only',
-        value: 'customers only',
-      },
-    ],
+    humanAlready: ['notes', 'fee', 'removal_reason'],
+    definitions: {
+      opening: definitions,
+      type: [
+        {
+          name: 'Female',
+          value: 'female',
+        },
+        {
+          name: 'Male',
+          value: 'male',
+        },
+        {
+          name: 'Female and Male',
+          value: 'female and male',
+        },
+        {
+          name: 'Unisex',
+          value: 'unisex',
+        },
+        {
+          name: 'Male Urinal',
+          value: 'male urinal',
+        },
+        {
+          name: 'Children Only',
+          value: 'children only',
+        },
+        {
+          name: 'None',
+          value: 'none',
+        },
+      ],
+      access: [
+        {
+          name: 'Public',
+          value: 'public',
+        },
+        {
+          name: 'Non-customers permitted',
+          value: 'permissive',
+        },
+        {
+          name: 'Customers only',
+          value: 'customers only',
+        },
+      ],
+    },
   },
 };

--- a/packages/ui/src/config.js
+++ b/packages/ui/src/config.js
@@ -17,7 +17,13 @@ export default {
   allowAddEditLoo: true,
   showBackButtons: false,
   looProps: {
-    humanAlready: ['notes', 'fee', 'removal_reason'],
+    canHumanize: [
+      'accessibleType',
+      'attended',
+      'babyChange',
+      'automatic',
+      'radar',
+    ],
     definitions: {
       opening: definitions,
       type: [

--- a/packages/ui/src/pages/AddEditPage.js
+++ b/packages/ui/src/pages/AddEditPage.js
@@ -47,7 +47,7 @@ class AddEditPage extends Component {
     },
   ];
 
-  optionsMap = config.looProps;
+  optionsMap = config.looProps.definitions;
 
   constructor(props) {
     super(props);

--- a/packages/ui/src/pages/LooPage.js
+++ b/packages/ui/src/pages/LooPage.js
@@ -122,10 +122,8 @@ class LooPage extends Component {
 
   humanizePropertyValue(val, property) {
     if (config.looProps.humanAlready.includes(property)) {
-      if (!(property === 'fee' && val === 'false')) {
-        // This was entered by a human, leave it as is
-        return val;
-      }
+      // This was entered by a human, leave it as is
+      return val;
     }
 
     if (config.looProps[property]) {

--- a/packages/ui/src/pages/LooPage.js
+++ b/packages/ui/src/pages/LooPage.js
@@ -22,8 +22,8 @@ import api from '../api';
 import config from '../config';
 
 class LooPage extends Component {
-  // Provides a mapping between loo properies and the values we want to display
-  humanizedValues = {
+  // Provides a mapping between loo property names and the values we want to display
+  humanizedPropNames = {
     type: 'Facilities',
     accessibleType: 'Accessible facilities',
     babyChange: 'Baby Changing',
@@ -108,23 +108,27 @@ class LooPage extends Component {
   // Wrapper to `api.humanize` which allows mappings between loo property values and the
   // text we want to display
   humanizePropertyName(val) {
-    if (this.humanizedValues[val]) {
-      return this.humanizedValues[val];
+    if (this.humanizedPropNames[val]) {
+      return this.humanizedPropNames[val];
     }
 
     return api.humanize(val);
   }
 
   humanizePropertyValue(val, property) {
+    if (config.looProps.humanAlready.includes(property)) {
+      if (!(property === 'fee' && val === 'false')) {
+        // This was entered by a human, leave it as is
+        return val;
+      }
+    }
+
     if (config.looProps[property]) {
+      // We may a human readable definition of this property value
       let override = config.looProps[property].find(s => s.value === val);
       if (override) {
         return override.name;
       }
-    }
-
-    if (this.humanizedValues[val]) {
-      return this.humanizedValues[val];
     }
 
     return api.humanize(val);

--- a/packages/ui/src/pages/LooPage.js
+++ b/packages/ui/src/pages/LooPage.js
@@ -131,8 +131,12 @@ class LooPage extends Component {
       }
     }
 
-    if (config.looProps.canHumanize.includes(property)) {
-      // We can humanize this kind of property to make it mroe human-readable
+    // Second condition is for an irregularity in our dataset; do this until we normalise better
+    if (
+      config.looProps.canHumanize.includes(property) ||
+      (property === 'fee' && val === 'false')
+    ) {
+      // We can humanize this kind of property to make it more human-readable
       return api.humanize(val);
     }
 

--- a/packages/ui/src/pages/LooPage.js
+++ b/packages/ui/src/pages/LooPage.js
@@ -121,20 +121,23 @@ class LooPage extends Component {
   }
 
   humanizePropertyValue(val, property) {
-    if (config.looProps.humanAlready.includes(property)) {
-      // This was entered by a human, leave it as is
-      return val;
-    }
-
-    if (config.looProps[property]) {
+    if (config.looProps.definitions[property]) {
       // We may a human readable definition of this property value
-      let override = config.looProps[property].find(s => s.value === val);
+      let override = config.looProps.definitions[property].find(
+        s => s.value === val
+      );
       if (override) {
         return override.name;
       }
     }
 
-    return api.humanize(val);
+    if (config.looProps.canHumanize.includes(property)) {
+      // We can humanize this kind of property to make it mroe human-readable
+      return api.humanize(val);
+    }
+
+    // This was likely entered as human-readable, leave it be
+    return val;
   }
 
   renderMain() {

--- a/packages/ui/src/pages/LooPage.js
+++ b/packages/ui/src/pages/LooPage.js
@@ -82,16 +82,21 @@ class LooPage extends Component {
   }
 
   getPropertyNames() {
-    // Apply a sort to match the property order of `this.propertiesSort`
-    var sorted = _.intersection(
-      this.propertiesSort,
-      Object.keys(this.props.loo.properties)
-    );
+    // All property names in our loo object
+    var names = Object.keys(this.props.loo.properties);
 
-    // Omit proprties found in the blacklist
-    return sorted.filter(property => {
-      return !this.propertiesBlacklist.includes(property);
-    });
+    // Pick out contained properties of known order, we'll put them at the front
+    var knownOrder = _.intersection(this.propertiesSort, names);
+
+    // Pick out all other properties that are not blacklisted, we'll put them after
+    var unknownOrder = _.difference(
+      names,
+      knownOrder,
+      this.propertiesBlacklist
+    );
+    unknownOrder.sort();
+
+    return knownOrder.concat(unknownOrder);
   }
 
   // Returns HTML representing the loo credibility score


### PR DESCRIPTION
This branch generally overhauls our humanization code for property values, fixing a number of issues:
* [We didn't include properties we didn't know the order of](https://github.com/neontribe/gbptm/commit/f4e1acb9a79de8484ed025d57b38799e8380032b)
* [We humanized all property values, even those that were already human-readable](https://github.com/neontribe/gbptm/commit/6d1dd1d82e5301da0cf429886e3220d600ed39e9), causing issues such as #223 (as a result, this closes #233)

One side-effect of fixing this issue is that the `fee` field may sometimes show as `false`, instead of `No` as before. This is because the `fee` field is, for the most part, human-readable and editable, and there is no practical way to distinguish between a user-entered `false` string and a pre-existing one.

To avoid writing code to accommodate a specific quirk of our data and, at the same time, risk translating user input erroneously, this has been left as-is. If it is considered to be preferable to retain the previous translation, this specific behaviour can be re-added. Worth considering in this is that about 3 in 26 of our loos will show their fee as `false`.