### PR TITLE
fix: avoid overlapping IE11 sidebar text

### DIFF
--- a/packages/ui/src/pages/css/home-page.module.css
+++ b/packages/ui/src/pages/css/home-page.module.css
@@ -1,6 +1,4 @@
 .container {
-	display: flex;
-	flex-direction: column;
 	flex: 1;
 }
 


### PR DESCRIPTION
closes #177 