### PR TITLE
fix: add array.prototype.find polyfill for IE support

### DIFF
--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -1,4 +1,5 @@
 // Polyfills
+import 'core-js/fn/array/find';
 import 'core-js/fn/array/includes';
 import 'core-js/fn/string/repeat';
 


### PR DESCRIPTION
The absence of `array.prototype.find` was causing problems in IE11. Adding a polyfill for this function mitigates that.