### PR TITLE
Map linking improvements

### DIFF
--- a/packages/ui/src/pages/LooPage.js
+++ b/packages/ui/src/pages/LooPage.js
@@ -131,7 +131,7 @@ class LooPage extends Component {
 
             <a
               href={
-                'https://maps.apple.com/?saddr=here&daddr=' +
+                'https://maps.apple.com/?dirflg=w&saddr=here&daddr=' +
                 [loo.geometry.coordinates[1], loo.geometry.coordinates[0]]
               }
               className={controls.btn}

--- a/packages/ui/src/pages/LooPage.js
+++ b/packages/ui/src/pages/LooPage.js
@@ -131,7 +131,7 @@ class LooPage extends Component {
 
             <a
               href={
-                'https://maps.apple.com/?dirflg=w&saddr=here&daddr=' +
+                'https://maps.apple.com/?dirflg=w&daddr=' +
                 [loo.geometry.coordinates[1], loo.geometry.coordinates[0]]
               }
               className={controls.btn}


### PR DESCRIPTION
* **Prefer walking directions (`dirflg=w`)**
* **Start the user at their current location (no `saddr` param)**
Although providing `saddr=here` would start users at their current location on desktops, it would not on the native Android navigation app, instead starting them at the unknown position `here`. This fixes this, at the cost of Google Maps opening with no starting location in desktop browsers. Though untested, it is expected that Apple devices will see no change from this, as Apple states that `saddr` defaults to `here`.