### PR TITLE
fix: add viewBox attr to svg's

### DIFF
--- a/packages/ui/src/images/pref-accessible-white.svg
+++ b/packages/ui/src/images/pref-accessible-white.svg
@@ -17,7 +17,8 @@
    sodipodi:docname="pref-baby.svg"
    inkscape:export-filename="/home/heydon/gbptm-ui/public/images/pref-access.png"
    inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   inkscape:export-ydpi="90"
+   viewBox="0 0 200 200">
   <defs
      id="defs3089" />
   <sodipodi:namedview

--- a/packages/ui/src/images/pref-accessible.svg
+++ b/packages/ui/src/images/pref-accessible.svg
@@ -17,7 +17,8 @@
    sodipodi:docname="pref-baby.svg"
    inkscape:export-filename="/home/heydon/gbptm-ui/public/images/pref-access.png"
    inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   inkscape:export-ydpi="90"
+   viewBox="0 0 200 200">
   <defs
      id="defs3089" />
   <sodipodi:namedview

--- a/packages/ui/src/images/pref-babychanging-white.svg
+++ b/packages/ui/src/images/pref-babychanging-white.svg
@@ -17,7 +17,8 @@
    sodipodi:docname="pref-male.svg"
    inkscape:export-filename="/home/heydon/gbptm-ui/public/images/pref-baby.png"
    inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   inkscape:export-ydpi="90"
+   viewBox="0 0 200 200">
   <defs
      id="defs3089" />
   <sodipodi:namedview

--- a/packages/ui/src/images/pref-babychanging.svg
+++ b/packages/ui/src/images/pref-babychanging.svg
@@ -17,7 +17,8 @@
    sodipodi:docname="pref-male.svg"
    inkscape:export-filename="/home/heydon/gbptm-ui/public/images/pref-baby.png"
    inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   inkscape:export-ydpi="90"
+   viewBox="0 0 200 200">
   <defs
      id="defs3089" />
   <sodipodi:namedview

--- a/packages/ui/src/images/pref-cost-white.svg
+++ b/packages/ui/src/images/pref-cost-white.svg
@@ -17,7 +17,8 @@
    sodipodi:docname="pref-access.svg"
    inkscape:export-filename="/home/heydon/gbptm-ui/public/images/pref-access.png"
    inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   inkscape:export-ydpi="90"
+   viewBox="0 0 200 200">
   <defs
      id="defs3089" />
   <sodipodi:namedview

--- a/packages/ui/src/images/pref-cost.svg
+++ b/packages/ui/src/images/pref-cost.svg
@@ -17,7 +17,8 @@
    sodipodi:docname="pref-access.svg"
    inkscape:export-filename="/home/heydon/gbptm-ui/public/images/pref-access.png"
    inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   inkscape:export-ydpi="90"
+   viewBox="0 0 200 200">
   <defs
      id="defs3089" />
   <sodipodi:namedview

--- a/packages/ui/src/images/pref-female-white.svg
+++ b/packages/ui/src/images/pref-female-white.svg
@@ -17,7 +17,8 @@
    sodipodi:docname="pref-access.svg"
    inkscape:export-filename="/home/heydon/gbptm-ui/public/images/pref-access.png"
    inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   inkscape:export-ydpi="90"
+   viewBox="0 0 200 200">
   <defs
      id="defs3089" />
   <sodipodi:namedview

--- a/packages/ui/src/images/pref-female.svg
+++ b/packages/ui/src/images/pref-female.svg
@@ -17,7 +17,8 @@
    sodipodi:docname="pref-access.svg"
    inkscape:export-filename="/home/heydon/gbptm-ui/public/images/pref-access.png"
    inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   inkscape:export-ydpi="90"
+   viewBox="0 0 200 200">
   <defs
      id="defs3089" />
   <sodipodi:namedview

--- a/packages/ui/src/images/pref-male-white.svg
+++ b/packages/ui/src/images/pref-male-white.svg
@@ -17,7 +17,8 @@
    sodipodi:docname="pref-female.svg"
    inkscape:export-filename="/home/heydon/gbptm-ui/public/images/pref-female.png"
    inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   inkscape:export-ydpi="90"
+   viewBox="0 0 200 200">
   <defs
      id="defs3089" />
   <sodipodi:namedview

--- a/packages/ui/src/images/pref-male.svg
+++ b/packages/ui/src/images/pref-male.svg
@@ -17,7 +17,8 @@
    sodipodi:docname="pref-female.svg"
    inkscape:export-filename="/home/heydon/gbptm-ui/public/images/pref-female.png"
    inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   inkscape:export-ydpi="90"
+   viewBox="0 0 200 200">
   <defs
      id="defs3089" />
   <sodipodi:namedview

--- a/packages/ui/src/images/pref-open-true.svg
+++ b/packages/ui/src/images/pref-open-true.svg
@@ -17,7 +17,8 @@
    sodipodi:docname="pref-open.svg"
    inkscape:export-filename="/home/heydon/gbptm-ui/public/images/pref-open.png"
    inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   inkscape:export-ydpi="90"
+   viewBox="0 0 200 200">
   <defs
      id="defs3089" />
   <sodipodi:namedview

--- a/packages/ui/src/images/pref-open-white.svg
+++ b/packages/ui/src/images/pref-open-white.svg
@@ -17,7 +17,8 @@
    sodipodi:docname="pref-free.svg"
    inkscape:export-filename="/home/heydon/gbptm-ui/public/images/pref-free.png"
    inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   inkscape:export-ydpi="90"
+   viewBox="0 0 200 200">
   <defs
      id="defs3089" />
   <sodipodi:namedview

--- a/packages/ui/src/images/pref-open.svg
+++ b/packages/ui/src/images/pref-open.svg
@@ -17,7 +17,8 @@
    sodipodi:docname="pref-free.svg"
    inkscape:export-filename="/home/heydon/gbptm-ui/public/images/pref-free.png"
    inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   inkscape:export-ydpi="90"
+   viewBox="0 0 200 200">
   <defs
      id="defs3089" />
   <sodipodi:namedview


### PR DESCRIPTION
fixes #195 

IE lte 11 needs a `viewBox` attribute to scale correctly.

Perhaps we could find a way to lint for this?

Also, these assets could definitely be minified.