### PR TITLE
Loading indicator enhancements

### DIFF
--- a/packages/ui/src/components/NearestLooMap.js
+++ b/packages/ui/src/components/NearestLooMap.js
@@ -14,6 +14,7 @@ import styles from './css/loo-map.module.css';
 class NearestLooMap extends Component {
   constructor(props) {
     super(props);
+    this.looMap = React.createRef();
     this.onMove = this.onMove.bind(this);
   }
 
@@ -21,12 +22,26 @@ class NearestLooMap extends Component {
     if (this.props.loo) {
       let [lng, lat] = this.props.loo.geometry.coordinates;
       this.props.actionFindNearbyRequest(lng, lat, config.nearestRadius);
+
+      if (this.looMap.current) {
+        this.looMap.current.refs.map.leafletElement.fire('dataloading');
+      }
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.looMap.current && this.props.loos !== prevProps.loos) {
+      this.looMap.current.refs.map.leafletElement.fire('dataload');
     }
   }
 
   onMove(lng, lat) {
     this.props.actionUpdateCenter({ lat, lng });
     this.props.actionFindNearbyRequest(lng, lat, config.nearestRadius);
+
+    if (this.looMap.current) {
+      this.looMap.current.refs.map.leafletElement.fire('dataloading');
+    }
   }
 
   render() {
@@ -51,6 +66,7 @@ class NearestLooMap extends Component {
         )}
 
         <LooMap
+          wrappedComponentRef={this.looMap}
           loos={loos}
           shouldCluster={true}
           showAttribution={true}

--- a/packages/ui/src/components/NearestLooMap.js
+++ b/packages/ui/src/components/NearestLooMap.js
@@ -14,7 +14,6 @@ import styles from './css/loo-map.module.css';
 class NearestLooMap extends Component {
   constructor(props) {
     super(props);
-    this.looMap = React.createRef();
     this.onMove = this.onMove.bind(this);
   }
 
@@ -23,15 +22,15 @@ class NearestLooMap extends Component {
       let [lng, lat] = this.props.loo.geometry.coordinates;
       this.props.actionFindNearbyRequest(lng, lat, config.nearestRadius);
 
-      if (this.looMap.current) {
-        this.looMap.current.refs.map.leafletElement.fire('dataloading');
+      if (this.looMap) {
+        this.looMap.refs.map.leafletElement.fire('dataloading');
       }
     }
   }
 
   componentDidUpdate(prevProps) {
-    if (this.looMap.current && this.props.loos !== prevProps.loos) {
-      this.looMap.current.refs.map.leafletElement.fire('dataload');
+    if (this.looMap && this.props.loos !== prevProps.loos) {
+      this.looMap.refs.map.leafletElement.fire('dataload');
     }
   }
 
@@ -39,8 +38,8 @@ class NearestLooMap extends Component {
     this.props.actionUpdateCenter({ lat, lng });
     this.props.actionFindNearbyRequest(lng, lat, config.nearestRadius);
 
-    if (this.looMap.current) {
-      this.looMap.current.refs.map.leafletElement.fire('dataloading');
+    if (this.looMap) {
+      this.looMap.refs.map.leafletElement.fire('dataloading');
     }
   }
 
@@ -66,7 +65,7 @@ class NearestLooMap extends Component {
         )}
 
         <LooMap
-          wrappedComponentRef={this.looMap}
+          wrappedComponentRef={it => (this.looMap = it)}
           loos={loos}
           shouldCluster={true}
           showAttribution={true}

--- a/packages/ui/src/pages/HomePage.js
+++ b/packages/ui/src/pages/HomePage.js
@@ -43,11 +43,13 @@ export class HomePage extends Component {
     this.props.actionHighlight(null);
   }
 
-  renderList() {
+  renderList(mobile) {
     var loos = this.props.loos;
 
-    // Loading
-    if (!loos) {
+    // Loading - either this is the first query of the user or they are on a
+    // mobile and so can't rely on the map's loading spinner to know the loos
+    // they see are outdated
+    if (!loos || (this.props.nearbyLoading && mobile)) {
       return (
         <Notification>
           <p>Fetching toilets&hellip;</p>
@@ -133,7 +135,7 @@ export class HomePage extends Component {
           className={styles.mobileContent}
         >
           {mode === 'list' && this.renderWelcome()}
-          {mode === 'list' && this.renderList()}
+          {mode === 'list' && this.renderList(true)}
           {mode === 'map' && (
             <div className={styles.mobileMap}>
               <div className={toiletMap.map}>{this.renderMap()}</div>
@@ -142,7 +144,7 @@ export class HomePage extends Component {
         </MediaQuery>
         <MediaQuery minWidth={config.viewport.mobile}>
           {this.renderWelcome()}
-          {this.renderList()}
+          {this.renderList(false)}
         </MediaQuery>
       </div>
     );
@@ -166,6 +168,7 @@ var mapStateToProps = state => ({
   loos: state.loos.nearby,
   app: state.app,
   isAuthenticated: state.auth.isAuthenticated,
+  loadingNearby: state.loos.loadingNearby,
 });
 
 var mapDispatchToProps = {

--- a/packages/ui/src/redux/modules/loos.js
+++ b/packages/ui/src/redux/modules/loos.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 
 export const FIND_NEARBY_REQUEST = 'LOOS/FIND_NEARBY/REQUEST';
+export const FIND_NEARBY_START = 'LOOS/FIND_NEARBY/START';
 export const FIND_NEARBY_SUCCESS = 'LOOS/FIND_NEARBY/SUCCESS';
 export const FIND_BY_ID_REQUEST = 'LOOS/FIND_BY_ID_REQUEST/SUCCESS';
 export const FIND_BY_ID_SUCCESS = 'LOOS/FIND_BY_ID_SUCCESS/SUCCESS';
@@ -20,6 +21,10 @@ export const actionFindNearbyRequest = (lng, lat, radius) => ({
     lat,
     radius,
   },
+});
+
+export const actionFindNearbyStart = () => ({
+  type: FIND_NEARBY_START,
 });
 
 export const actionFindNearbySuccess = loos => ({
@@ -89,10 +94,18 @@ const ACTION_HANDLERS = {
     };
   },
 
+  [FIND_NEARBY_START]: function(state, action) {
+    return {
+      ...state,
+      loadingNearby: true,
+    };
+  },
+
   [FIND_NEARBY_SUCCESS]: function(state, action) {
     return {
       ...state,
       nearby: action.payload.loos || [],
+      loadingNearby: false,
     };
   },
 
@@ -108,6 +121,7 @@ const ACTION_HANDLERS = {
 
 const initialState = {
   byId: {},
+  loadingNearby: false,
 };
 
 // Reducer

--- a/packages/ui/src/redux/sagas/loos.js
+++ b/packages/ui/src/redux/sagas/loos.js
@@ -9,6 +9,7 @@ import {
   FIND_BY_ID_REQUEST,
   REPORT_REQUEST,
   REMOVE_REQUEST,
+  actionFindNearbyStart,
   actionFindNearbySuccess,
   actionFindByIdSuccess,
   actionReportSuccess,
@@ -20,6 +21,7 @@ import { LOGGED_IN } from '../modules/auth';
 
 export default function makeLoosSaga(auth) {
   function* findNearbyLoosSaga(action) {
+    yield put(actionFindNearbyStart());
     var { lng, lat, radius } = action.payload;
     var loos = yield call(api.findLoos, lng, lat, radius);
     yield put(actionFindNearbySuccess(loos));


### PR DESCRIPTION
closes #249

Previously, we only had a loading indicator for map tiles. This wasn't much good for working out if you were waiting for nearer loos to load in. Now:

* **The `leaflet` map spinner is spun when nearby loos are being fetched** - [this was added](https://github.com/neontribe/gbptm/compare/unity...loading-indicator#diff-27a3e73b51939405340ccd887244536f) the [only way `leaflet-loading` allows](https://github.com/ebrelsford/Leaflet.loading/blob/bfc810ea31f55e0a30ed65cbb0bf7f8bfc857bce/README.md#usage), with events, which is unfortunately quite un-React
* **On the mobile list-view of nearby toilets, a loading message is shown instead of the toilets for the previous query, to ensure stale toilet results aren't shown** - this was added as a loading boolean in the redux state, as we wouldn't want to also show this as loading when fetching map tiles; the responsive code here is a bit icky, so any suggestions to tidy that up would be welcome