### PR TITLE
fix: be less specific about what a small viewport is

### DIFF
--- a/packages/ui/src/components/css/layout.module.css
+++ b/packages/ui/src/components/css/layout.module.css
@@ -14,8 +14,7 @@
 }
 
 @media only screen
-	and (max-device-width: 750px)
-	and (orientation: portrait) {
+	and (max-width: 750px) {
 
 	.mainContainer {
 		max-width: none;


### PR DESCRIPTION
closes #236

The previous media query was a little too specific:
* Landscape devices with thin screens were not targeted
* Devices with large screens but smaller browser windows were not targeted

The new media query cares only about the width of the viewport, fixing #236.