### PR TITLE
Clustering improvements

### DIFF
--- a/packages/ui/src/components/LooMap.js
+++ b/packages/ui/src/components/LooMap.js
@@ -134,32 +134,30 @@ export class LooMap extends Component {
       var map = (this.leafletElement = this.refs.map.leafletElement);
       var center = map.getCenter();
 
-      if (this.props.shouldCluster) {
-        // Create a marker cluster layer which will be reset each time this
-        // component receives props
-        var clusterLayer = L.markerClusterGroup({
-          showCoverageOnHover: false,
-          disableClusteringAtZoom: 15,
-          iconCreateFunction: cluster => {
-            var count = cluster.getChildCount();
+      // Create a marker cluster layer which will be reset each time this
+      // component receives props
+      var clusterLayer = L.markerClusterGroup({
+        showCoverageOnHover: false,
+        disableClusteringAtZoom: 15,
+        iconCreateFunction: cluster => {
+          var count = cluster.getChildCount();
 
-            return L.divIcon({
-              html: `<div class=${styles.cluster}>
-                                <span class=${styles.count}>${count}</span>
-                                toilets
-                            </div>`,
-            });
-          },
-        });
+          return L.divIcon({
+            html: `<div class=${styles.cluster}>
+                              <span class=${styles.count}>${count}</span>
+                              toilets
+                          </div>`,
+          });
+        },
+      });
 
-        this.setState({
-          clusterLayer,
-        });
-      }
-
-      this.props.onInitialised(map);
-      this.props.onUpdateCenter(center);
+      this.setState({
+        clusterLayer,
+      });
     }
+
+    this.props.onInitialised(map);
+    this.props.onUpdateCenter(center);
   }
 
   onMove(event) {
@@ -196,7 +194,7 @@ export class LooMap extends Component {
     // Cluster
     // Manually adds markers by directly calling the Leaflet API instead of using the `react-leaflet`
     // `Marker` component
-    if (this.props.shouldCluster && this.state.clusterLayer) {
+    if (this.state.clusterLayer) {
       this.state.clusterLayer.clearLayers();
 
       looList.forEach((loo, index) => {
@@ -277,45 +275,6 @@ export class LooMap extends Component {
         {this.props.showLocateControl && <LocateMapControl />}
         {this.props.showFullscreenControl && <FullscreenMapControl />}
 
-        {/* Render individual Marker Components if we're not clustering */}
-        {!this.props.shouldCluster &&
-          looList.map((loo, index) => {
-            // Determine whether to highlight the current loo instance
-            var highlight =
-              this.props.highlight && loo._id === this.props.highlight;
-
-            // Consider adding an index to the loo
-            var count = null;
-            if (
-              this.props.countFrom !== null &&
-              index < this.props.countLimit
-            ) {
-              count = this.props.countFrom + index;
-            }
-
-            return (
-              <Marker
-                key={index}
-                position={[
-                  loo.geometry.coordinates[1],
-                  loo.geometry.coordinates[0],
-                ]}
-                icon={
-                  new L.LooIcon({
-                    iconSize: [25, 41],
-                    iconAnchor: [12.5, 41],
-                    iconUrl: highlight ? markerIconHighlight : markerIcon,
-                    iconRetinaUrl: highlight
-                      ? markerIconRetinaHighlight
-                      : markerIconRetina,
-                    index: count,
-                  })
-                }
-                onClick={_.partial(this.onMarkerClick, loo)}
-              />
-            );
-          })}
-
         {this.props.showCenter &&
           center && (
             <Marker
@@ -348,9 +307,6 @@ LooMap.propTypes = {
       lng: PropTypes.number,
     }),
   ]).isRequired,
-
-  // Allows markers to form clusters using the 'leaflet.markercluster' plugin
-  shouldCluster: PropTypes.bool,
 
   initialZoom: PropTypes.number,
   minZoom: PropTypes.number,
@@ -399,7 +355,6 @@ LooMap.propTypes = {
 LooMap.defaultProps = {
   loos: [],
   className: styles.map,
-  shouldCluster: false,
   initialZoom: config.initialZoom,
   minZoom: config.minZoom,
   maxZoom: config.maxZoom,

--- a/packages/ui/src/components/LooMap.js
+++ b/packages/ui/src/components/LooMap.js
@@ -235,11 +235,12 @@ export class LooMap extends Component {
     // diff'ing; this will leave us with markers to remove in loosThen and
     // markers to add in loosNow
     for (let id of Object.keys(loosNow)) {
+      // Can a loo's marker (not including icon) be left untouched?
       if (
         loosThen.hasOwnProperty(id) &&
-        _.isEqual(loosThen[id].geometry, loosNow[id].geometry)
+        loosThen[id].geohash === loosNow[id].geohash
       ) {
-        // We don't need to update these
+        // Yes, we don't need to update these; same loo in the same place
         delete loosThen[id];
         delete loosNow[id];
       }

--- a/packages/ui/src/components/LooMap.js
+++ b/packages/ui/src/components/LooMap.js
@@ -27,6 +27,32 @@ import markerIconRetinaHighlight from '../images/marker-icon-highlight-2x.png';
 import markerCircle from '../images/map-icons/circle.svg';
 
 L.LooIcon = L.Icon.extend({
+  options: {
+    iconSize: [25, 41],
+    iconAnchor: [12.5, 41],
+    highlight: false,
+  },
+
+  initialize: function(options) {
+    if (options.highlight) {
+      // Add highlight properties
+      this.options = {
+        ...this.options,
+        iconUrl: markerIconHighlight,
+        iconRetinaUrl: markerIconRetinaHighlight,
+        className: styles.markerHighlighted,
+      };
+    } else {
+      this.options = {
+        ...this.options,
+        iconUrl: markerIcon,
+        iconRetinaUrl: markerIconRetina,
+      };
+    }
+
+    L.Util.setOptions(this, options);
+  },
+
   createIcon: function() {
     var img = this._createImg(this._getIconUrl('icon'));
 
@@ -151,8 +177,12 @@ export class LooMap extends Component {
         },
       });
 
+      this.leafletElement.addLayer(clusterLayer);
+
+      // Set state and, afterwards, add loo markers
       this.setState({
         clusterLayer,
+        markers: {},
       });
     }
 
@@ -180,61 +210,120 @@ export class LooMap extends Component {
     }
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    // New cluster layer, we probably remounted
+    if (prevState.clusterLayer !== this.state.clusterLayer) {
+      // We need to re-add everything
+      this.addRemoveMarkers(_.keyBy(this.props.loos, '_id'), {});
+      return;
+    }
+
+    // Otherwise, we only care if markers and their icons could've changed
+    if (
+      prevProps.loos === this.props.loos &&
+      prevProps.highlight === this.props.highlight &&
+      prevProps.countLimit === this.props.countLimit &&
+      prevProps.countFrom === this.props.countFrom
+    ) {
+      return;
+    }
+
+    let loosThen = _.keyBy(prevProps.loos, '_id');
+    let loosNow = _.keyBy(this.props.loos, '_id');
+
+    // Remove elements that have unchanged location from both, effectively
+    // diff'ing; this will leave us with markers to remove in loosThen and
+    // markers to add in loosNow
+    for (let id of Object.keys(loosNow)) {
+      if (
+        loosThen.hasOwnProperty(id) &&
+        _.isEqual(loosThen[id].geometry, loosNow[id].geometry)
+      ) {
+        // We don't need to update these
+        delete loosThen[id];
+        delete loosNow[id];
+      }
+    }
+
+    // Update the markers as appropriate
+    this.addRemoveMarkers(loosNow, loosThen);
+  }
+
+  addRemoveMarkers(loosToAdd, loosToRemove) {
+    // Assumes loosToAdd and loosToRemove have already been checked for duplicates
+    const markers = { ...this.state.markers };
+
+    // Remove markers in bulk
+    const markersToRemove = [];
+    for (const id of Object.keys(loosToRemove)) {
+      markersToRemove.push(markers[id]);
+      delete markers[id];
+    }
+    this.state.clusterLayer.removeLayers(markersToRemove);
+
+    // Add markers in bulk
+    const markersToAdd = [];
+    for (let [id, loo] of Object.entries(loosToAdd)) {
+      // Determine whether to highlight the current loo instance
+      var highlight = this.props.highlight && loo._id === this.props.highlight;
+
+      var position = {
+        lat: loo.geometry.coordinates[1],
+        lng: loo.geometry.coordinates[0],
+      };
+
+      var icon = new L.LooIcon({ highlight });
+      var marker = L.marker(position, { icon }); // We'll work out numbering below
+
+      // Individual marker click handler
+      marker.on('click', _.partial(this.onMarkerClick, loo));
+      markersToAdd.push(marker);
+      markers[id] = marker;
+    }
+    this.state.clusterLayer.addLayers(markersToAdd);
+
+    // Update icons to reflect appropriate number and highlight status
+    for (let i = 0; i < this.props.loos.length; i++) {
+      const loo = this.props.loos[i];
+
+      let index = undefined;
+      if (this.props.countLimit && i < this.props.countLimit) {
+        index = this.props.countFrom + i;
+      }
+
+      let highlight = false;
+      if (this.props.highlight && loo._id === this.props.highlight) {
+        highlight = true;
+      }
+
+      // Do we need to change the icon based on properties then and now?
+      const iconOptionsNow = markers[loo._id].options.icon.options;
+      if (
+        iconOptionsNow.index !== index ||
+        iconOptionsNow.highlight !== highlight
+      ) {
+        markers[loo._id].setIcon(
+          new L.LooIcon({
+            highlight,
+            index,
+          })
+        );
+      }
+    }
+
+    // Cache markers for each loo
+    this.setState({
+      ...this.state,
+      markers,
+    });
+  }
+
   render() {
     // Center point for the map view
     var center = this.props.initialPosition;
 
     if (this.leafletElement) {
       center = this.leafletElement.getCenter();
-    }
-
-    // Clone `loos` to avoid props mutation
-    var looList = this.props.loos.slice(0);
-
-    // Cluster
-    // Manually adds markers by directly calling the Leaflet API instead of using the `react-leaflet`
-    // `Marker` component
-    if (this.state.clusterLayer) {
-      this.state.clusterLayer.clearLayers();
-
-      looList.forEach((loo, index) => {
-        // Determine whether to highlight the current loo instance
-        var highlight =
-          this.props.highlight && loo._id === this.props.highlight;
-
-        var position = {
-          lat: loo.geometry.coordinates[1],
-          lng: loo.geometry.coordinates[0],
-        };
-
-        // Consider adding an index to the loo
-        var count = null;
-        if (this.props.countFrom !== null && index < this.props.countLimit) {
-          count = this.props.countFrom + index;
-        }
-
-        var icon = new L.LooIcon({
-          iconSize: [25, 41],
-          iconAnchor: [12.5, 41],
-          iconUrl: highlight ? markerIconHighlight : markerIcon,
-          iconRetinaUrl: highlight
-            ? markerIconRetinaHighlight
-            : markerIconRetina,
-          className: highlight && styles.markerHighlighted,
-          index: count,
-        });
-
-        var marker = L.marker(position, {
-          icon: icon,
-        });
-
-        // Individual marker click handler
-        marker.on('click', _.partial(this.onMarkerClick, loo));
-
-        this.state.clusterLayer.addLayer(marker);
-      });
-
-      this.leafletElement.addLayer(this.state.clusterLayer);
     }
 
     var className = this.props.className;
@@ -293,7 +382,7 @@ export class LooMap extends Component {
 }
 
 LooMap.propTypes = {
-  // An array of loo instances to be represented as map markers
+  // An array of loo instances to be represented as map markers, assumed to be from closest to furthest away
   loos: PropTypes.array.isRequired,
 
   // Optional CSS class name to override the map element styles

--- a/packages/ui/src/components/NearestLooMap.js
+++ b/packages/ui/src/components/NearestLooMap.js
@@ -55,7 +55,6 @@ class NearestLooMap extends Component {
           loos={loos}
           countFrom={this.props.numberNearest ? 1 : null}
           countLimit={5}
-          shouldCluster={true}
           showAttribution={true}
           showLocation={true}
           showSearchControl={true}

--- a/packages/ui/src/pages/LooPage.js
+++ b/packages/ui/src/pages/LooPage.js
@@ -291,6 +291,7 @@ class LooPage extends Component {
           showCenter: false,
           preventDragging: true,
           minZoom: config.initialZoom,
+          countLimit: null,
         }}
       />
     );


### PR DESCRIPTION
closes #241

## Cleanup

Clustering was [enabled everywhere](https://github.com/neontribe/gbptm/commit/fa6d54d5d3198a35dd6c0213b86eba72a9403458). Prior to this, we had separate branched implementations for clustered and unclustered `LooMap`s. We no longer had the explicit need to disable clustering, so we were able to scoop up some cheap maintainability by removing the unclustered implementation.

## Performance

Previously, on every render we regenerated all markers. There were a few issues with this:

* Obvious performance hit, especially in areas such as London with over 1000 loos within 50km
* Clustering was not deterministic and, as such, on moving cluster sizes would visibly change even when the loos in the area had not

One would hope that React could be used to reduce some of this effort but, sadly, the `react-leaflet-markercluster` library has [memory leaks reported](https://github.com/YUzhva/react-leaflet-markercluster/issues/70) (which is odd considering [the very small size of the project](https://github.com/YUzhva/react-leaflet-markercluster/blob/master/src/react-leaflet-markercluster.js); all of the garbage collection is handled upstream in `react-leaflet`).

We wanted to update markers instead of recreate them but as `leaflet-markercluster` is not built around React and has a rather state-y nature we must use `componentDidUpdate` to do this as opposed to `render`. [Markers are now being created and destroyed there](https://github.com/neontribe/gbptm/commit/b2ac95fc7479077d81e697e702f6226426bffb59). Caching markers in the component's state and diffing previous and present `loos` prop values massively reduces the number of recreated markers and stops us from having to clear and re-add markers on each render.

## Future Performance

Adding markers in chunks is yet to be tried, although now using one call to `addLayers` and `removeLayers` in each update does mean that it would be as simple as changing `leaflet-markercluster`'s options to enable this.

It is worth considering that chunking would leave us with a blind spot in our UI. At present, the user can clearly see when all loos have been loaded; there are none and then, after a small delay, they are all there. Enabling chunking could potentially show some markers before the rest are added, which would be misleading unless we added UI to show that there were still loos to come.

I am yet to implement chunking because of this potential issue and would be interested to see how the current changes affect performance before we consider implementing it.