### PR TITLE
Scope optimisations

### DIFF
--- a/packages/api/src/models/loo.js
+++ b/packages/api/src/models/loo.js
@@ -22,6 +22,19 @@ looSchema.statics.findNear = function(lon, lat, radius) {
         'properties.active': true,
       },
     },
+    {
+      $project: {
+        geometry: 1,
+        distance: 1,
+        properties: {
+          fee: 1,
+          accessibleType: 1,
+          opening: 1,
+          type: 1,
+          babyChange: 1,
+        },
+      },
+    },
   ]);
 };
 

--- a/packages/ui/src/components/LooMap.js
+++ b/packages/ui/src/components/LooMap.js
@@ -238,7 +238,7 @@ export class LooMap extends Component {
       // Can a loo's marker (not including icon) be left untouched?
       if (
         loosThen.hasOwnProperty(id) &&
-        loosThen[id].geohash === loosNow[id].geohash
+        _.isEqual(loosThen[id].geometry, loosNow[id].geometry)
       ) {
         // Yes, we don't need to update these; same loo in the same place
         delete loosThen[id];


### PR DESCRIPTION
Just a small contribution to #233:

We served loos in their entirety in our near loos endpoint, however, we only need loo coordinates for the map markers and some basic property values for the user's preference icons. This limits the loos in the response to just these properties, leading to nearly 75% smaller response sizes in most scenarios.