### PR TITLE
fix: number loos on only the Home and About page

### DIFF
--- a/packages/ui/src/components/LooListItem.js
+++ b/packages/ui/src/components/LooListItem.js
@@ -26,6 +26,7 @@ class LooListItem extends Component {
       >
         <LooMap
           countFrom={this.props.index}
+          countLimit={1}
           showZoomControls={false}
           preventZoom={true}
           preventDragging={true}

--- a/packages/ui/src/components/LooMap.js
+++ b/packages/ui/src/components/LooMap.js
@@ -277,7 +277,7 @@ export class LooMap extends Component {
       const loo = this.props.loos[i];
 
       let index = undefined;
-      if (this.props.countLimit && i < this.props.countLimit) {
+      if (i < this.props.countLimit) {
         index = this.props.countFrom + i;
       }
 
@@ -395,7 +395,7 @@ LooMap.propTypes = {
   showLocateControl: PropTypes.bool,
   showAttribution: PropTypes.bool,
 
-  // Label loo markers with icons from a starting number, for a limited number of loos
+  // Label loo markers from a starting number, for a limited number of loos
   countFrom: PropTypes.number,
   countLimit: PropTypes.number,
 
@@ -443,7 +443,8 @@ LooMap.defaultProps = {
   showAttribution: false,
   showCenter: false,
   showCrosshair: false,
-  countLimit: 10,
+  countLimit: 0,
+  countFrom: 1,
   onMove: Function.prototype,
   onZoom: Function.prototype,
   onInitialised: Function.prototype,

--- a/packages/ui/src/components/NearestLooMap.js
+++ b/packages/ui/src/components/NearestLooMap.js
@@ -68,8 +68,7 @@ class NearestLooMap extends Component {
         <LooMap
           wrappedComponentRef={it => (this.looMap = it)}
           loos={loos}
-          countFrom={this.props.numberNearest ? 1 : null}
-          countLimit={5}
+          countLimit={this.props.numberNearest ? 5 : 0}
           showAttribution={true}
           showLocation={true}
           showSearchControl={true}

--- a/packages/ui/src/pages/AboutPage.js
+++ b/packages/ui/src/pages/AboutPage.js
@@ -171,7 +171,7 @@ class AboutPage extends Component {
   }
 
   renderMap() {
-    return <NearestLooMap />;
+    return <NearestLooMap numberNearest />;
   }
 
   render() {

--- a/packages/ui/src/pages/HomePage.js
+++ b/packages/ui/src/pages/HomePage.js
@@ -152,7 +152,7 @@ export class HomePage extends Component {
   }
 
   renderMap() {
-    return <NearestLooMap numberNearest={true} />;
+    return <NearestLooMap numberNearest />;
   }
 
   render() {

--- a/packages/ui/src/pages/LooPage.js
+++ b/packages/ui/src/pages/LooPage.js
@@ -291,7 +291,6 @@ class LooPage extends Component {
           showCenter: false,
           preventDragging: true,
           minZoom: config.initialZoom,
-          countLimit: null,
         }}
       />
     );


### PR DESCRIPTION
closes #285

Previously, we were deciding whether to number loos or not based on whether the `countLimit` prop in `LooMap` was null, which didn't make much sense. Further, this was implemented incorrectly in `NearestLooMap`, which was setting `countFrom` to `null` in an attempt to stifle counting; counting was only disabled on the single loo page because we were misusing another one of `NearestLooMap`'s props.

Now, `countLimit` is just set to 0 to turn off counting in `LooMap`. `NearestLooMap` uses this to enable or disable counting (as decided by its own `numberNearest` property).

This fixes the issue at #285 where loos would be numbered from `0` to `5` when one was attempting to disable counting with `NearestLooMap`'s `numberNearest` prop.