### PR TITLE
fix: show newlines in loo property values

### DIFF
--- a/packages/ui/src/pages/css/loo-page.module.css
+++ b/packages/ui/src/pages/css/loo-page.module.css
@@ -35,6 +35,10 @@
 	line-height: 1;
 }
 
+.propertyValue {
+  white-space: pre-line;
+}
+
 .dataTable {
 	table-layout: fixed;
 	width: 100%;


### PR DESCRIPTION
closes #253

Sometimes property values have newlines in them; this alteration to the CSS ensures that they're displayed.