### PR TITLE
feat: replace center marker circle with crosshair

### DIFF
--- a/packages/ui/src/components/LooMap.js
+++ b/packages/ui/src/components/LooMap.js
@@ -13,7 +13,7 @@ import 'leaflet-loading';
 // https://github.com/perliedman/leaflet-control-geocoder/issues/150
 import 'leaflet-control-geocoder/src';
 
-import { Map, TileLayer, Marker } from 'react-leaflet';
+import { Map, TileLayer } from 'react-leaflet';
 import GeolocationMapControl from './GeolocationMapControl.js';
 import LocateMapControl from './LocateMapControl.js';
 
@@ -25,7 +25,6 @@ import markerIcon from '../images/marker-icon.png';
 import markerIconRetina from '../images/marker-icon-2x.png';
 import markerIconHighlight from '../images/marker-icon-highlight.png';
 import markerIconRetinaHighlight from '../images/marker-icon-highlight-2x.png';
-import markerCircle from '../images/map-icons/circle.svg';
 
 L.LooIcon = L.Icon.extend({
   options: {
@@ -277,7 +276,7 @@ export class LooMap extends Component {
     }
 
     var className = this.props.className;
-    if (this.props.showCrosshair) {
+    if (this.props.showCenter) {
       className += ` ${styles['with-crosshair']}`;
       className += ' map--zindexfix';
     }
@@ -286,7 +285,7 @@ export class LooMap extends Component {
     return (
       <Map
         ref="map"
-        center={this.props.initialPosition}
+        center={center}
         zoom={this.props.initialZoom}
         zoomControl={!this.props.preventZoom && this.props.showZoomControls}
         scrollWheelZoom={!this.props.preventZoom}
@@ -312,19 +311,6 @@ export class LooMap extends Component {
 
         {this.props.showSearchControl && <GeolocationMapControl />}
         {this.props.showLocateControl && <LocateMapControl />}
-
-        {this.props.showCenter &&
-          center && (
-            <Marker
-              position={center}
-              icon={L.icon({
-                iconSize: [16, 16],
-                iconAnchor: [8, 8],
-                iconUrl: markerCircle,
-                className: styles.center,
-              })}
-            />
-          )}
       </Map>
     );
   }
@@ -362,7 +348,7 @@ LooMap.propTypes = {
   // Note this also has a dependency on `preventZoom`
   showZoomControls: PropTypes.bool,
 
-  // Draws a circle to indicate the center of the map
+  // Draws a crosshair to indicate the center of the map
   showCenter: PropTypes.bool,
 
   // Callback fn called with the new `lat`, `lng` and `radius` values.
@@ -376,9 +362,6 @@ LooMap.propTypes = {
   // Callback fn called with a reference to the leaflet element.
   // Fired once the component has mounted
   onInitialised: PropTypes.func,
-
-  // Shows a crosshair at the center of the map
-  showCrosshair: PropTypes.bool,
 
   // Called on `onMove` and `onInitialised`
   onUpdateCenter: PropTypes.func,
@@ -402,7 +385,6 @@ LooMap.defaultProps = {
   showZoomControls: true,
   showAttribution: false,
   showCenter: false,
-  showCrosshair: false,
   countLimit: 0,
   countFrom: 1,
   onMove: Function.prototype,

--- a/packages/ui/src/components/css/loo-map.module.css
+++ b/packages/ui/src/components/css/loo-map.module.css
@@ -78,10 +78,6 @@
 	background-color: rgba(0, 0, 0, 0.8);
 }
 
-.center {
-	opacity: 0.5;
-}
-
 :global(.leaflet-div-icon) {
 	border: 0 !important;
 	background: none !important;

--- a/packages/ui/src/pages/AddEditPage.js
+++ b/packages/ui/src/pages/AddEditPage.js
@@ -443,10 +443,8 @@ class AddEditPage extends Component {
           showLocation: false,
           showSearchControl: false,
           showLocateControl: false,
-          showCenter: false,
           preventDragging: false,
           minZoom: config.editMinZoom,
-          showCrosshair: true,
         }}
       />
     );


### PR DESCRIPTION
closes #248
closes #272

Everywhere we showed the center marker, we now show the crosshair instead. This means that we show the crosshair everywhere except the individual loo page and remove page, as relative distances/numbering are not used there.

Within the source, the crosshair is now under the control of `showCenter` and the old crosshair-specific props have been removed.

If the crosshair is too loud, we could look at making it less so for scenarios in which the location of a loo is not being determined (e.g. through opacity, relative size to viewport, etc).