### PR TITLE
4 move to reach router

### DIFF
--- a/packages/admin/example.env
+++ b/packages/admin/example.env
@@ -1,0 +1,2 @@
+REACT_APP_GBPTM_API=https://gbptm-stage.herokuapp.com/api
+NODE_ENV=development

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -3,7 +3,7 @@
   "version": "2.4.0",
   "private": true,
   "homepage": "/admin",
-  "proxy": "https://gbptm-unity.herokuapp.com",
+  "proxy": "https://localhost:8080",
   "devDependencies": {
     "react-scripts": "next"
   },
@@ -27,7 +27,7 @@
     "react-leaflet": "1.9.1"
   },
   "scripts": {
-    "start": "SKIP_PREFLIGHT_CHECK=true react-scripts start",
+    "dev": "SKIP_PREFLIGHT_CHECK=true react-scripts start",
     "build": "SKIP_PREFLIGHT_CHECK=true react-scripts build"
   },
   "eslintConfig": {

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@material-ui/core": "1.2.3",
     "@material-ui/icons": "1.1.0",
+    "@reach/router": "1.1.1",
     "chart.js": "2.5.0",
     "leaflet": "1.3.1",
     "lodash": "4.17.10",
@@ -23,8 +24,7 @@
     "react-animated-number": "0.4.4",
     "react-chartjs-2": "2.7.2",
     "react-dom": "16.4.2",
-    "react-leaflet": "1.9.1",
-    "react-router": "3.2.1"
+    "react-leaflet": "1.9.1"
   },
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true react-scripts start",

--- a/packages/admin/src/components/AppLayout.js
+++ b/packages/admin/src/components/AppLayout.js
@@ -19,7 +19,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import StatsIcon from '@material-ui/icons/Assessment';
 import SearchIcon from '@material-ui/icons/Search';
 //import ToolsIcon from '@material-ui/icons/Build';
-import { Link, withRouter } from 'react-router';
+import { Link } from '@reach/router';
 
 const styles = {
   root: {
@@ -87,10 +87,8 @@ class AppLayout extends Component {
               <List>
                 <ListItem button>
                   <Link
-                    to={{
-                      pathname: '/statistics',
-                      query: this.state.defaultStatScope,
-                    }}
+                    to="statistics"
+                    state={{ ...this.state.defaultStatScope }}
                   >
                     <ListItemIcon>
                       <StatsIcon />
@@ -100,10 +98,8 @@ class AppLayout extends Component {
                 </ListItem>
                 <ListItem button>
                   <Link
-                    to={{
-                      pathname: '/statistics/areas',
-                      query: this.state.defaultStatScope,
-                    }}
+                    to="/statistics/areas"
+                    state={{ ...this.state.defaultStatScope }}
                   >
                     <ListItemIcon>
                       <StatsIcon />
@@ -112,7 +108,7 @@ class AppLayout extends Component {
                   </Link>
                 </ListItem>
                 <ListItem button>
-                  <Link to={'/search'}>
+                  <Link to="/search">
                     <ListItemIcon>
                       <SearchIcon />
                     </ListItemIcon>
@@ -138,4 +134,4 @@ class AppLayout extends Component {
   }
 }
 
-export default withRouter(withStyles(styles)(AppLayout));
+export default withStyles(styles)(AppLayout);

--- a/packages/admin/src/components/Search.js
+++ b/packages/admin/src/components/Search.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import settings from '../lib/settings';
 import _ from 'lodash';
-import { withRouter } from 'react-router';
 import queryString from 'query-string';
 
 import { withStyles } from '@material-ui/core/styles';
@@ -12,6 +11,8 @@ import GridList from '@material-ui/core/GridList';
 import Toolbar from '@material-ui/core/Toolbar';
 import Button from '@material-ui/core/Button';
 import LooTile from './LooTile';
+
+import { navigate } from '@reach/router';
 
 const styles = {
   gridRoot: {
@@ -36,7 +37,7 @@ class Search extends Component {
 
     this.state = {
       searching: false,
-      searchParams: Object.assign({}, defaults, props.location.query),
+      searchParams: Object.assign({}, defaults, props.location.state.query),
       areas: [],
     };
 
@@ -49,7 +50,7 @@ class Search extends Component {
   }
 
   doSearch(query) {
-    var q = query || this.props.location.query;
+    var q = query || this.props.location.state.query;
     if (!_.isEmpty(q)) {
       this.setState({ searching: true });
       fetch(settings.getItem('apiUrl') + '/search?' + queryString.stringify(q))
@@ -87,15 +88,20 @@ class Search extends Component {
   }
 
   UNSAFE_componentWillReceiveProps(props) {
-    if (!_.isEqual(props.location.query, this.props.location.query)) {
-      this.doSearch(props.location.query);
+    if (
+      !_.isEqual(props.location.state.query, this.props.location.state.query)
+    ) {
+      this.doSearch(props.location.state.query);
     }
   }
 
   submit() {
-    this.props.router.push({
-      pathname: this.props.location.pathname,
-      query: this.state.searchParams,
+    navigate(this.props.location.pathname, {
+      state: {
+        query: {
+          text: this.state.searchParams.text,
+        },
+      },
     });
   }
 
@@ -119,9 +125,10 @@ class Search extends Component {
     var searchParams = Object.assign({}, this.state.searchParams);
     searchParams.page = (parseInt(searchParams.page, 10) + inc).toString();
     this.setState({ searchParams });
-    this.props.router.push({
-      pathname: this.props.location.pathname,
-      query: searchParams,
+    navigate(this.props.location.pathname, {
+      state: {
+        query: searchParams,
+      },
     });
   }
 
@@ -247,4 +254,4 @@ class Search extends Component {
   }
 }
 
-export default withRouter(withStyles(styles)(Search));
+export default withStyles(styles)(Search);

--- a/packages/admin/src/components/Search.js
+++ b/packages/admin/src/components/Search.js
@@ -93,6 +93,7 @@ class Search extends Component {
 
   UNSAFE_componentWillReceiveProps(props) {
     if (
+      !this.props.location.state ||
       !_.isEqual(props.location.state.query, this.props.location.state.query)
     ) {
       this.doSearch(props.location.state.query);

--- a/packages/admin/src/components/Search.js
+++ b/packages/admin/src/components/Search.js
@@ -37,7 +37,10 @@ class Search extends Component {
 
     this.state = {
       searching: false,
-      searchParams: Object.assign({}, defaults, props.location.state.query),
+      searchParams: {
+        ...defaults,
+        ...(props.location.state && props.location.state.query),
+      },
       areas: [],
     };
 
@@ -50,7 +53,8 @@ class Search extends Component {
   }
 
   doSearch(query) {
-    var q = query || this.props.location.state.query;
+    var q =
+      query || (this.props.location.state && this.props.location.state.query);
     if (!_.isEmpty(q)) {
       this.setState({ searching: true });
       fetch(settings.getItem('apiUrl') + '/search?' + queryString.stringify(q))

--- a/packages/admin/src/components/Statistics.js
+++ b/packages/admin/src/components/Statistics.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { navigate } from '@reach/router';
+import { navigate, Location } from '@reach/router';
 import _ from 'lodash';
 import settings from '../lib/settings';
 import moment from 'moment';
@@ -59,17 +59,21 @@ class Statistics extends Component {
   render() {
     return this.state.loadedInitialData ? (
       <div>
-        <QueryScoper
-          start={this.props.location.state.start}
-          end={this.props.location.state.end}
-          minDate={this.state.minDate}
-          maxDate={this.state.maxDate}
-          areaType={this.props.location.state.areaType}
-          areaTypeList={this.state.areaTypeList}
-          area={this.props.location.state.area}
-          areaData={this.props.location.areaData}
-          onChange={this.updateQuery}
-        />
+        <Location>
+          {({ location }) => (
+            <QueryScoper
+              start={location.state && location.state.start}
+              end={location.state && location.state.end}
+              minDate={this.state.minDate}
+              maxDate={this.state.maxDate}
+              areaType={location.state && location.state.areaType}
+              areaTypeList={location.state && this.state.areaTypeList}
+              area={location.state && location.state.area}
+              areaData={location.areaData}
+              onChange={this.updateQuery}
+            />
+          )}
+        </Location>
         {this.props.children}
       </div>
     ) : (

--- a/packages/admin/src/components/Statistics.js
+++ b/packages/admin/src/components/Statistics.js
@@ -60,19 +60,21 @@ class Statistics extends Component {
     return this.state.loadedInitialData ? (
       <div>
         <Location>
-          {({ location }) => (
-            <QueryScoper
-              start={location.state && location.state.start}
-              end={location.state && location.state.end}
-              minDate={this.state.minDate}
-              maxDate={this.state.maxDate}
-              areaType={location.state && location.state.areaType}
-              areaTypeList={location.state && this.state.areaTypeList}
-              area={location.state && location.state.area}
-              areaData={location.areaData}
-              onChange={this.updateQuery}
-            />
-          )}
+          {({ location }) =>
+            location.state && (
+              <QueryScoper
+                start={location.state.start}
+                end={location.state.end}
+                minDate={this.state.minDate}
+                maxDate={this.state.maxDate}
+                areaType={location.state.areaType}
+                areaTypeList={this.state.areaTypeList}
+                area={location.state.area}
+                areaData={location.state.areaData}
+                onChange={this.updateQuery}
+              />
+            )
+          }
         </Location>
         {this.props.children}
       </div>

--- a/packages/admin/src/components/Statistics.js
+++ b/packages/admin/src/components/Statistics.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
+import { navigate } from '@reach/router';
 import _ from 'lodash';
 import settings from '../lib/settings';
 import moment from 'moment';
-import { withRouter } from 'react-router';
 
 import QueryScoper from './stats/QueryScoper';
 
@@ -49,9 +49,10 @@ class Statistics extends Component {
   }
 
   updateQuery(query) {
-    this.props.router.push({
-      pathname: this.props.location.pathname,
-      query,
+    navigate(this.props.location.pathname, {
+      state: {
+        query: query,
+      },
     });
   }
 
@@ -59,14 +60,14 @@ class Statistics extends Component {
     return this.state.loadedInitialData ? (
       <div>
         <QueryScoper
-          start={this.props.location.query.start}
-          end={this.props.location.query.end}
+          start={this.props.location.state.start}
+          end={this.props.location.state.end}
           minDate={this.state.minDate}
           maxDate={this.state.maxDate}
-          areaType={this.props.location.query.areaType}
+          areaType={this.props.location.state.areaType}
           areaTypeList={this.state.areaTypeList}
-          area={this.props.location.query.area}
-          areaData={this.state.areaData}
+          area={this.props.location.state.area}
+          areaData={this.props.location.areaData}
           onChange={this.updateQuery}
         />
         {this.props.children}
@@ -77,4 +78,4 @@ class Statistics extends Component {
   }
 }
 
-export default withRouter(Statistics);
+export default Statistics;

--- a/packages/admin/src/components/stats/AreaComparisonStats.js
+++ b/packages/admin/src/components/stats/AreaComparisonStats.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import _ from 'lodash';
 import settings from '../../lib/settings';
 import queryString from 'query-string';
-import { Link } from 'react-router';
+import { Link } from '@reach/router';
 
 //import RefreshIndicator from 'material-ui/RefreshIndicator';
 
@@ -141,14 +141,7 @@ class AreaComparisonStats extends Component {
                   );
                 })}
                 <TableCell key={'c_listLink_' + index}>
-                  <Link
-                    to={{
-                      pathname: '/search',
-                      query: {
-                        area_name: row._id,
-                      },
-                    }}
-                  >
+                  <Link to="/search" state={{ query: { area_name: row._id } }}>
                     view loos
                   </Link>
                 </TableCell>

--- a/packages/admin/src/components/stats/HeadlineStats.js
+++ b/packages/admin/src/components/stats/HeadlineStats.js
@@ -173,12 +173,12 @@ class HeadlineStats extends Component {
           <GridListTile key="Subheader" cols={2} style={{ height: 'auto' }}>
             <ListSubheader component="div">
               <h2>Headline Counts</h2>
-              {`${moment(this.props.location.query.start).format(
+              {`${moment(this.props.location.state.start).format(
                 'ddd, MMM Do YYYY'
-              )} to ${moment(this.props.location.query.end).format(
+              )} to ${moment(this.props.location.state.end).format(
                 'ddd, MMM Do YYYY'
-              )} in ${this.props.location.query.area ||
-                this.props.location.query.areaType}`}
+              )} in ${this.props.location.state.area ||
+                this.props.location.state.areaType}`}
             </ListSubheader>
           </GridListTile>
           <GridListTile rows={2} cols={1}>

--- a/packages/admin/src/components/stats/HeadlineStats.js
+++ b/packages/admin/src/components/stats/HeadlineStats.js
@@ -173,17 +173,18 @@ class HeadlineStats extends Component {
         <GridList cols={2} cellHeight={200} padding={1}>
           <GridListTile key="Subheader" cols={2} style={{ height: 'auto' }}>
             <Location>
-              {({ location }) => (
-                <ListSubheader component="div">
-                  <h2>Headline Counts</h2>
-                  {`${moment(location.state && location.state.start).format(
-                    'ddd, MMM Do YYYY'
-                  )} to ${moment(location.state && location.state.end).format(
-                    'ddd, MMM Do YYYY'
-                  )} in ${(location.state && location.state.area) ||
-                    (location.state && location.state.areaType)}`}
-                </ListSubheader>
-              )}
+              {({ location }) =>
+                location.state && (
+                  <ListSubheader component="div">
+                    <h2>Headline Counts</h2>
+                    {`${moment(location.state.start).format(
+                      'ddd, MMM Do YYYY'
+                    )} to ${moment(location.state.end).format(
+                      'ddd, MMM Do YYYY'
+                    )} in ${location.state.area || location.state.areaType}`}
+                  </ListSubheader>
+                )
+              }
             </Location>
           </GridListTile>
           <GridListTile rows={2} cols={1}>

--- a/packages/admin/src/components/stats/HeadlineStats.js
+++ b/packages/admin/src/components/stats/HeadlineStats.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Location } from '@reach/router';
 import _ from 'lodash';
 import settings from '../../lib/settings';
 import queryString from 'query-string';
@@ -171,15 +172,19 @@ class HeadlineStats extends Component {
 
         <GridList cols={2} cellHeight={200} padding={1}>
           <GridListTile key="Subheader" cols={2} style={{ height: 'auto' }}>
-            <ListSubheader component="div">
-              <h2>Headline Counts</h2>
-              {`${moment(this.props.location.state.start).format(
-                'ddd, MMM Do YYYY'
-              )} to ${moment(this.props.location.state.end).format(
-                'ddd, MMM Do YYYY'
-              )} in ${this.props.location.state.area ||
-                this.props.location.state.areaType}`}
-            </ListSubheader>
+            <Location>
+              {({ location }) => (
+                <ListSubheader component="div">
+                  <h2>Headline Counts</h2>
+                  {`${moment(location.state && location.state.start).format(
+                    'ddd, MMM Do YYYY'
+                  )} to ${moment(location.state && location.state.end).format(
+                    'ddd, MMM Do YYYY'
+                  )} in ${(location.state && location.state.area) ||
+                    (location.state && location.state.areaType)}`}
+                </ListSubheader>
+              )}
+            </Location>
           </GridListTile>
           <GridListTile rows={2} cols={1}>
             <Doughnut

--- a/packages/admin/src/index.js
+++ b/packages/admin/src/index.js
@@ -11,27 +11,19 @@ import Search from './components/Search';
 
 import './css/index.css';
 
-import {
-  Router,
-  Route,
-  IndexRoute,
-  IndexRedirect,
-  hashHistory,
-} from 'react-router';
+import { Router } from '@reach/router';
 
 ReactDOM.render(
-  <Router history={hashHistory}>
-    <Route path="/" component={AppLayout}>
-      <IndexRedirect to="search" />
-      <Route path="home" component={Home} />
-      <Route path="search" component={Search} />
-      <Route path="statistics" component={Statistics}>
-        <IndexRoute component={HeadlineStats} />
-        <Route path="areas" component={AreaComparisonStats} />
-      </Route>
-
+  <Router>
+    <AppLayout path="/">
+      <Home path="home" />
+      <Search default path="search" />
+      <Statistics path="statistics">
+        <HeadlineStats default />
+        <AreaComparisonStats path="areas" />
+      </Statistics>
       {/* <Route path="tools" component={Tools}/> */}
-    </Route>
+    </AppLayout>
   </Router>,
   document.getElementById('root')
 );

--- a/packages/admin/src/lib/settings.js
+++ b/packages/admin/src/lib/settings.js
@@ -6,7 +6,11 @@ class Settings {
   getItem(key) {
     var val = global.localStorage.getItem(key);
     if (!val && key === 'apiUrl') {
-      return '/api';
+      let apiUrl =
+        process.env.NODE_ENV === 'production'
+          ? '/api'
+          : process.env.REACT_APP_GBPTM_API || '/api';
+      return apiUrl;
     }
     return val ? JSON.parse(val) : null;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,6 +1488,16 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.1.tgz#53f349bb986ab273d601175aa1b25a655ab90ee3"
 
+"@reach/router@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.1.1.tgz#24a5b20f1cc9e55e2cbcdc454fb82c94db479a81"
+  dependencies:
+    create-react-context "^0.2.1"
+    invariant "^2.2.3"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
+    warning "^3.0.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -3492,13 +3502,12 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.1:
-  version "15.6.3"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
+create-react-context@^0.2.1:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
   dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
+    fbjs "^0.8.0"
+    gud "^1.0.0"
 
 cross-spawn@6.0.5:
   version "6.0.5"
@@ -4817,7 +4826,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -5361,6 +5370,10 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
 
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+
 gzip-size@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-4.1.0.tgz#8ae096257eabe7d69c45be2b67c448124ffb517c"
@@ -5541,15 +5554,6 @@ helmet@3.13.0:
 hide-powered-by@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hide-powered-by/-/hide-powered-by-1.0.0.tgz#4a85ad65881f62857fc70af7174a1184dccce32b"
-
-history@^3.0.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/history/-/history-3.3.0.tgz#fcedcce8f12975371545d735461033579a6dae9c"
-  dependencies:
-    invariant "^2.2.1"
-    loose-envify "^1.2.0"
-    query-string "^4.2.2"
-    warning "^3.0.0"
 
 history@^4.7.2:
   version "4.7.2"
@@ -5927,7 +5931,7 @@ internal-ip@1.2.0:
   dependencies:
     meow "^3.3.0"
 
-invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -9508,7 +9512,7 @@ query-string@4.2.3:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^4.1.0, query-string@^4.2.2:
+query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
   dependencies:
@@ -9765,18 +9769,6 @@ react-router-hash-link@^1.2.0:
   resolved "https://registry.yarnpkg.com/react-router-hash-link/-/react-router-hash-link-1.2.0.tgz#ce824cc5f0502ce9b0686bb6dd9c08659b24094c"
   dependencies:
     prop-types "^15.6.0"
-
-react-router@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.1.tgz#b9a3279962bdfbe684c8bd0482b81ef288f0f244"
-  dependencies:
-    create-react-class "^15.5.1"
-    history "^3.0.0"
-    hoist-non-react-statics "^2.3.1"
-    invariant "^2.2.1"
-    loose-envify "^1.2.0"
-    prop-types "^15.5.6"
-    warning "^3.0.0"
 
 react-router@^4.3.1:
   version "4.3.1"


### PR DESCRIPTION
resolves https://github.com/neontribe/gbptm/issues/349

* Substitute react-router with reach-router
* Test paths to ensure functionality remains the same

## Some notes:
* The `navigate` method provided by `reach-router` is now used instead of `.push` to navigate to routes.
* State is now passed around on the `props.location.state` object instead of `props.location.query`. Hence we now use `props.location.state.query` in a lot of places.