### PR TITLE
352 search by contributor

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -12,6 +12,7 @@
     "@material-ui/icons": "3.0.1",
     "@reach/router": "1.1.1",
     "chart.js": "2.7.2",
+    "downshift": "2.2.0",
     "leaflet": "1.3.1",
     "lodash": "4.17.10",
     "moment": "2.22.2",

--- a/packages/admin/src/components/Search.js
+++ b/packages/admin/src/components/Search.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
 import settings from '../lib/settings';
 import _ from 'lodash';
+import deburr from 'lodash/deburr';
 import queryString from 'query-string';
+import Downshift from 'downshift';
 
 import { withStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
@@ -12,8 +14,13 @@ import Toolbar from '@material-ui/core/Toolbar';
 import Button from '@material-ui/core/Button';
 import Select from '@material-ui/core/Select';
 import Input from '@material-ui/core/Input';
+import Paper from '@material-ui/core/Paper';
 import MenuItem from '@material-ui/core/MenuItem';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import IconButton from '@material-ui/core/IconButton';
 import LooTile from './LooTile';
+
+import RemoveCircle from '@material-ui/icons/RemoveCircle';
 
 import { navigate } from '@reach/router';
 
@@ -30,12 +37,55 @@ const styles = {
   },
 };
 
+function renderInput(inputProps) {
+  const { InputProps, classes, ref, ...other } = inputProps;
+
+  return (
+    <TextField
+      InputProps={{
+        inputRef: ref,
+        classes: {
+          root: classes.inputRoot,
+        },
+        ...InputProps,
+      }}
+      {...other}
+    />
+  );
+}
+
+function renderSuggestion({
+  suggestion,
+  index,
+  itemProps,
+  highlightedIndex,
+  selectedItem,
+}) {
+  const isHighlighted = highlightedIndex === index;
+  const isSelected = (selectedItem || '').indexOf(suggestion.label) > -1;
+
+  return (
+    <MenuItem
+      {...itemProps}
+      key={suggestion.label}
+      selected={isHighlighted}
+      component="div"
+      style={{
+        fontWeight: isSelected ? 500 : 400,
+      }}
+    >
+      {suggestion.label}
+    </MenuItem>
+  );
+}
+
 class Search extends Component {
   constructor(props) {
     super(props);
 
     var defaults = {
       text: '',
+      area_name: '',
     };
 
     const parsedQuery = queryString.parse(this.props.location.search);
@@ -52,12 +102,15 @@ class Search extends Component {
     this.submit = this.submit.bind(this);
     this.doSearch = this.doSearch.bind(this);
     this.fetchAreaData = this.fetchAreaData.bind(this);
+    this.fetchContributorData = this.fetchContributorData.bind(this);
     this.updateSearchParam = this.updateSearchParam.bind(this);
     this.updateSearchField = this.updateSearchField.bind(this);
+    this.getContributorSuggestions = this.getContributorSuggestions.bind(this);
   }
 
   componentDidMount() {
     this.doSearch(this.state.searchParams);
+    this.fetchContributorData();
     this.fetchAreaData();
   }
 
@@ -94,6 +147,19 @@ class Search extends Component {
   }
 
   /**
+   * Fetches a list of contributors and attaches to state.
+   */
+  async fetchContributorData() {
+    const searchUrl = settings.getItem('apiUrl') + '/statistics/contributors';
+    const response = await fetch(searchUrl);
+    const result = await response.json();
+    const contributors = Object.keys(result).map(x => ({ label: x }));
+    this.setState({
+      contributors: contributors,
+    });
+  }
+
+  /**
    * Navigates to updated query string and submits a search to the API.
    *
    * Omits any empty search paramaters from the search.
@@ -119,6 +185,7 @@ class Search extends Component {
    * @param {*} evt
    */
   updateSearchField(key, evt) {
+    console.log(key, evt);
     this.updateSearchParam(key, evt.target.value);
   }
 
@@ -138,6 +205,32 @@ class Search extends Component {
     this.setState({
       searchParams,
     });
+  }
+
+  /**
+   *
+   * Returns an array of contributor suggestions based upon an input string.
+   *
+   * @param {*} value
+   */
+  getContributorSuggestions(value) {
+    const inputValue = deburr(value.trim()).toLowerCase();
+    const inputLength = inputValue.length;
+    let count = 0;
+
+    return inputLength === 0
+      ? []
+      : this.state.contributors.filter(suggestion => {
+          const keep =
+            count < 5 &&
+            suggestion.label.slice(0, inputLength).toLowerCase() === inputValue;
+
+          if (keep) {
+            count += 1;
+          }
+
+          return keep;
+        });
   }
 
   render() {
@@ -168,6 +261,55 @@ class Search extends Component {
                 </MenuItem>
               ))}
             </Select>
+
+            <Downshift
+              id="attribution-search"
+              onChange={_.partial(this.updateSearchParam, 'attributions')}
+            >
+              {({
+                getInputProps,
+                getItemProps,
+                isOpen,
+                inputValue,
+                selectedItem,
+                highlightedIndex,
+                clearSelection,
+              }) => (
+                <div className={classes.container}>
+                  {renderInput({
+                    fullWidth: true,
+                    classes,
+                    InputProps: getInputProps({
+                      placeholder: 'Search contributor submissions.',
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <IconButton
+                            aria-label="Toggle password visibility"
+                            onClick={clearSelection}
+                          >
+                            <RemoveCircle />
+                          </IconButton>
+                        </InputAdornment>
+                      ),
+                    }),
+                  })}
+                  {isOpen ? (
+                    <Paper className={classes.paper} square>
+                      {this.getContributorSuggestions(inputValue).map(
+                        (suggestion, index) =>
+                          renderSuggestion({
+                            suggestion,
+                            index,
+                            itemProps: getItemProps({ item: suggestion.label }),
+                            highlightedIndex,
+                            selectedItem,
+                          })
+                      )}
+                    </Paper>
+                  ) : null}
+                </div>
+              )}
+            </Downshift>
 
             <Toolbar>
               <Button

--- a/packages/admin/src/components/Search.js
+++ b/packages/admin/src/components/Search.js
@@ -255,7 +255,7 @@ class Search extends Component {
             >
               <MenuItem value="">All</MenuItem>
               {this.state.areas.map((item, i) => (
-                <MenuItem value={item} key={i}>
+                <MenuItem value={item} key={item}>
                   {item}
                 </MenuItem>
               ))}

--- a/packages/admin/src/components/Search.js
+++ b/packages/admin/src/components/Search.js
@@ -185,7 +185,6 @@ class Search extends Component {
    * @param {*} evt
    */
   updateSearchField(key, evt) {
-    console.log(key, evt);
     this.updateSearchParam(key, evt.target.value);
   }
 

--- a/packages/api/src/routes/search.js
+++ b/packages/api/src/routes/search.js
@@ -17,6 +17,14 @@ router.get('/', async (req, res) => {
   }
   delete params.text;
 
+  if (params.attributions) {
+    query.$and = [];
+    query.$and.push({
+      attributions: { $all: [params.attributions] },
+    });
+  }
+  delete params.attributions;
+
   // Arbitrary text searches have been removed until a way is found that is not
   // prone to ReDoS attacks or indexing every possible property by text
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3154,6 +3154,10 @@ compression@1.7.3, compression@^1.5.2:
     safe-buffer "5.1.2"
     vary "~1.1.2"
 
+compute-scroll-into-view@^1.0.2:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.8.tgz#ad0acd869dc6dc1069201532c025783a30ea177d"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -4070,6 +4074,13 @@ dotenv-expand@4.2.0:
 dotenv@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
+
+downshift@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-2.2.0.tgz#08887b6196eaccf1d7a3d26c5ac65630f4f43b7b"
+  dependencies:
+    compute-scroll-into-view "^1.0.2"
+    prop-types "^15.6.0"
 
 duplexer3@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
resolves #352 

* Implements an autocomplete search box for contributors using the method recommended in the material-ui docs.
  * Adds the "Downshift" library which handles state, with the text input and suggestions being passed in using render props.
  * Loads in contributors using the `/statistics/contributors` endpoint.
  * Includes a button to easily clear the input.

* Handles a new `attributions` param in the API to look up toilets attributed to a specific contributor.