### PR TITLE
feat: implement a loo detail page

### DIFF
--- a/packages/admin/src/components/AppLayout.js
+++ b/packages/admin/src/components/AppLayout.js
@@ -98,7 +98,7 @@ class AppLayout extends Component {
                 </ListItem>
                 <ListItem button>
                   <Link
-                    to="/statistics/areas"
+                    to="statistics/areas"
                     state={{ ...this.state.defaultStatScope }}
                   >
                     <ListItemIcon>
@@ -108,7 +108,7 @@ class AppLayout extends Component {
                   </Link>
                 </ListItem>
                 <ListItem button>
-                  <Link to="/search">
+                  <Link to="search">
                     <ListItemIcon>
                       <SearchIcon />
                     </ListItemIcon>

--- a/packages/admin/src/components/LooTable.js
+++ b/packages/admin/src/components/LooTable.js
@@ -18,7 +18,7 @@ const styles = theme => ({
   },
 });
 
-function SimpleTable(props) {
+function LooTable(props) {
   const { classes, data } = props;
 
   return (
@@ -47,9 +47,9 @@ function SimpleTable(props) {
   );
 }
 
-SimpleTable.propTypes = {
+LooTable.propTypes = {
   classes: PropTypes.object.isRequired,
   data: PropTypes.array.isRequired,
 };
 
-export default withStyles(styles)(SimpleTable);
+export default withStyles(styles)(LooTable);

--- a/packages/admin/src/components/LooTable.js
+++ b/packages/admin/src/components/LooTable.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Paper from '@material-ui/core/Paper';
+
+const styles = theme => ({
+  root: {
+    width: '100%',
+    overflowX: 'auto',
+  },
+  table: {
+    minWidth: 700,
+  },
+});
+
+function SimpleTable(props) {
+  const { classes, data } = props;
+
+  return (
+    <Paper className={classes.root}>
+      <Table className={classes.table}>
+        <TableHead>
+          <TableRow>
+            <TableCell>Property</TableCell>
+            <TableCell>Value</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.map(n => {
+            return (
+              <TableRow key={n[0]}>
+                <TableCell component="th" scope="row">
+                  {n[0]}
+                </TableCell>
+                <TableCell>{JSON.stringify(n[1])}</TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </Paper>
+  );
+}
+
+SimpleTable.propTypes = {
+  classes: PropTypes.object.isRequired,
+  data: PropTypes.array.isRequired,
+};
+
+export default withStyles(styles)(SimpleTable);

--- a/packages/admin/src/components/LooTile.js
+++ b/packages/admin/src/components/LooTile.js
@@ -1,18 +1,26 @@
 import React, { Component } from 'react';
 import propTypes from 'prop-types';
 import settings from '../lib/settings';
-import GridListTile from '@material-ui/core/GridListTile';
-import GridListTileBar from '@material-ui/core/GridListTileBar';
+import classNames from 'classnames';
+import { withStyles } from '@material-ui/core/styles';
 import { Map, Marker, TileLayer } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
 import icon from 'leaflet/dist/images/marker-icon.png';
 import iconShadow from 'leaflet/dist/images/marker-shadow.png';
+
 let DefaultIcon = L.icon({
   iconUrl: icon,
   shadowUrl: iconShadow,
 });
 L.Marker.prototype.options.icon = DefaultIcon;
+
+const styles = theme => ({
+  looTile: {
+    width: '100%',
+    height: 300,
+  },
+});
 
 class LooTile extends Component {
   constructor(props) {
@@ -28,8 +36,9 @@ class LooTile extends Component {
   }
 
   render() {
+    const { className, mapProps, classes } = this.props;
     return (
-      <GridListTile style={{ width: '33.3%' }}>
+      <div className={classNames(className) || classes.looTile}>
         <Map
           center={this.state.location}
           zoomControl={false}
@@ -39,6 +48,7 @@ class LooTile extends Component {
           scrollWheelZoom={false}
           doubleClickZoom={false}
           zoom={12}
+          {...mapProps}
         >
           <TileLayer
             url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -46,8 +56,7 @@ class LooTile extends Component {
           />
           <Marker position={this.state.location} />
         </Map>
-        <GridListTileBar title={this.props.loo.properties.name || 'Unnamed'} />
-      </GridListTile>
+      </div>
     );
   }
 }
@@ -56,4 +65,4 @@ LooTile.propTypes = {
   loo: propTypes.object.isRequired,
 };
 
-export default LooTile;
+export default withStyles(styles)(LooTile);

--- a/packages/admin/src/components/LooView.js
+++ b/packages/admin/src/components/LooView.js
@@ -1,0 +1,175 @@
+import React, { Component } from 'react';
+import settings from '../lib/settings';
+import classNames from 'classnames';
+import LooTile from './LooTile';
+import LooTable from './LooTable';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+import ExpansionPanel from '@material-ui/core/ExpansionPanel';
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import Typography from '@material-ui/core/Typography';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = theme => ({
+  looTile: {
+    height: '100%',
+    width: 'auto',
+  },
+  mapTile: {
+    width: '100%',
+    height: 300,
+  },
+  appBarSpacer: theme.mixins.toolbar,
+  root: {
+    flexGrow: 1,
+  },
+  paper: {
+    padding: theme.spacing.unit * 2,
+    textAlign: 'center',
+    color: theme.palette.text.secondary,
+  },
+  heading: {
+    fontSize: theme.typography.pxToRem(15),
+    flexBasis: '33.33%',
+    flexShrink: 0,
+  },
+  secondaryHeading: {
+    fontSize: theme.typography.pxToRem(15),
+    color: theme.palette.text.secondary,
+  },
+  expansionRoot: {
+    width: '100%',
+  },
+});
+
+class LooView extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loadingData: true,
+      expanded: null,
+      loo: {},
+    };
+
+    this.fetchLooData = this.fetchLooData.bind(this);
+  }
+
+  componentDidMount() {
+    this.fetchLooData();
+  }
+
+  async fetchLooData() {
+    this.setState({ loadingData: true });
+    const path =
+      settings.getItem('apiUrl') +
+      '/loos/' +
+      this.props.looId +
+      '?populateReports=true';
+    const response = await fetch(path);
+    const result = await response.json();
+    this.setState({
+      loadingData: false,
+      loo: {
+        ...result,
+      },
+    });
+  }
+
+  handleChange = panel => (event, expanded) => {
+    this.setState({
+      expanded: expanded ? panel : false,
+    });
+  };
+
+  render() {
+    const { loo, loadingData, expanded } = this.state;
+    const { classes } = this.props;
+
+    if (loadingData) {
+      return <p>Loading Loo Info</p>;
+    }
+
+    return (
+      <div className={classes.root}>
+        <div className={classes.appBarSpacer} />
+        <Grid container spacing={24}>
+          <Grid item md={6} sm={12}>
+            <Typography variant="display1" gutterBottom>
+              {loo.properties.name}
+            </Typography>
+            {loo.properties.area.map(val => {
+              return (
+                <Typography key={val._id} variant="subheading" gutterBottom>
+                  {val.name} / {val.type}
+                </Typography>
+              );
+            })}
+          </Grid>
+          <Grid container item md={6} sm={12}>
+            <Paper className={classNames(classes.paper, classes.mapTile)}>
+              <LooTile
+                className={classes.looTile}
+                loo={loo}
+                mapProps={{
+                  scrollWheelZoom: true,
+                  dragging: true,
+                }}
+              />
+            </Paper>
+          </Grid>
+
+          <Grid container item sm={12}>
+            <Grid item sm={12}>
+              <Typography variant="display1" gutterBottom>
+                Toilet Data
+              </Typography>
+              <Typography variant="subheading" gutterBottom>
+                Data attached to this loo.
+              </Typography>
+            </Grid>
+            <LooTable data={Object.entries(loo.properties)} />
+          </Grid>
+
+          <Grid container item sm={12}>
+            <Grid item sm={12}>
+              <Typography variant="display1" gutterBottom>
+                Loo Reports
+              </Typography>
+              <Typography variant="subheading" gutterBottom>
+                Contributions towards this loo.
+              </Typography>
+            </Grid>
+            <div className={classes.expansionRoot}>
+              {loo.reports.map(value => {
+                return (
+                  <ExpansionPanel
+                    key={value._id}
+                    expanded={expanded === value._id}
+                    onChange={this.handleChange(value._id)}
+                  >
+                    <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+                      <Typography className={classes.heading}>
+                        Report from: {value.attribution}
+                      </Typography>
+                      <Typography className={classes.secondaryHeading}>
+                        Created: {value.updatedAt}
+                      </Typography>
+                    </ExpansionPanelSummary>
+
+                    <ExpansionPanelDetails>
+                      <LooTable data={Object.entries(value.properties)} />
+                    </ExpansionPanelDetails>
+                  </ExpansionPanel>
+                );
+              })}
+            </div>
+          </Grid>
+        </Grid>
+      </div>
+    );
+  }
+}
+
+export default withStyles(styles)(LooView);

--- a/packages/admin/src/components/Search.js
+++ b/packages/admin/src/components/Search.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import deburr from 'lodash/deburr';
 import queryString from 'query-string';
 import Downshift from 'downshift';
-
 import { withStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
@@ -20,11 +19,11 @@ import SearchIcon from '@material-ui/icons/Search';
 import MenuItem from '@material-ui/core/MenuItem';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import IconButton from '@material-ui/core/IconButton';
+import GridListTile from '@material-ui/core/GridListTile';
+import GridListTileBar from '@material-ui/core/GridListTileBar';
 import LooTile from './LooTile';
-
 import RemoveCircle from '@material-ui/icons/RemoveCircle';
-
-import { navigate } from '@reach/router';
+import { Link, navigate } from '@reach/router';
 
 const styles = {
   gridRoot: {
@@ -153,9 +152,7 @@ class Search extends Component {
     const searchUrl = settings.getItem('apiUrl') + '/admin_geo/areas';
     const response = await fetch(searchUrl);
     const result = await response.json();
-
     result.All = _.uniq(_.flatten(_.values(result))).sort();
-
     this.setState({
       areas: result.All,
     });
@@ -400,7 +397,16 @@ class Search extends Component {
                 <div className={classes.gridRoot}>
                   <GridList className={classes.gridList} cellHeight={180}>
                     {this.state.results.docs.map(l => {
-                      return <LooTile key={l._id} loo={l} />;
+                      return (
+                        <GridListTile key={l._id} style={{ width: '33.3%' }}>
+                          <LooTile loo={l} />
+                          <Link to={`/loos/${l._id}`}>
+                            <GridListTileBar
+                              title={l.properties.name || 'Unnamed'}
+                            />
+                          </Link>
+                        </GridListTile>
+                      );
                     })}
                   </GridList>
                 </div>

--- a/packages/admin/src/components/Search.js
+++ b/packages/admin/src/components/Search.js
@@ -185,7 +185,7 @@ class Search extends Component {
     }
 
     const query = queryString.stringify(omitEmpty);
-    await navigate(`/search?${query}`);
+    await navigate(`search?${query}`);
     this.doSearch(omitEmpty);
   }
 
@@ -400,7 +400,7 @@ class Search extends Component {
                       return (
                         <GridListTile key={l._id} style={{ width: '33.3%' }}>
                           <LooTile loo={l} />
-                          <Link to={`/loos/${l._id}`}>
+                          <Link to={`../loos/${l._id}`}>
                             <GridListTileBar
                               title={l.properties.name || 'Unnamed'}
                             />

--- a/packages/admin/src/components/stats/AreaComparisonStats.js
+++ b/packages/admin/src/components/stats/AreaComparisonStats.js
@@ -139,7 +139,9 @@ class AreaComparisonStats extends Component {
                   );
                 })}
                 <TableCell key={'c_listLink_' + index}>
-                  <Link to={`/search?area_name=${row._id}`}>view loos</Link>
+                  <Link to={`../../search?area_name=${row._id}`}>
+                    view loos
+                  </Link>
                 </TableCell>
               </TableRow>
             ))}

--- a/packages/admin/src/index.js
+++ b/packages/admin/src/index.js
@@ -15,8 +15,8 @@ import { Router } from '@reach/router';
 
 ReactDOM.render(
   <Router>
-    <AppLayout path="/">
-      <Home path="/" />
+    <AppLayout path="/admin">
+      <Home default path="/" />
       <Search path="search" />
       <LooView path="loos/:looId" />
       <Statistics path="statistics">

--- a/packages/admin/src/index.js
+++ b/packages/admin/src/index.js
@@ -7,6 +7,7 @@ import Statistics from './components/Statistics';
 import HeadlineStats from './components/stats/HeadlineStats';
 import AreaComparisonStats from './components/stats/AreaComparisonStats';
 import Search from './components/Search';
+import LooView from './components/LooView';
 
 import './css/index.css';
 
@@ -17,6 +18,7 @@ ReactDOM.render(
     <AppLayout path="/">
       <Home path="/" />
       <Search path="search" />
+      <LooView path="loos/:looId" />
       <Statistics path="statistics">
         <HeadlineStats default />
         <AreaComparisonStats path="areas" />

--- a/packages/admin/src/index.js
+++ b/packages/admin/src/index.js
@@ -16,7 +16,7 @@ import { Router } from '@reach/router';
 ReactDOM.render(
   <Router>
     <AppLayout path="/admin">
-      <Home default path="/" />
+      <Home default path="home" />
       <Search path="search" />
       <LooView path="loos/:looId" />
       <Statistics path="statistics">

--- a/packages/api/src/routes/loos.js
+++ b/packages/api/src/routes/loos.js
@@ -54,7 +54,7 @@ router.get('/:id', async (req, res) => {
     res.status(200).json(populatedReportsLoo);
     return;
   }
-  console.log(loo);
+
   res.status(200).json(loo);
 });
 

--- a/packages/api/src/routes/loos.js
+++ b/packages/api/src/routes/loos.js
@@ -44,10 +44,17 @@ router.get('/:id/updateArea', async (req, res) => {
  */
 router.get('/:id', async (req, res) => {
   const loo = await Loo.findById(req.params.id).exec();
+
   if (!loo) {
     return res.status(404).end();
   }
 
+  if (req.query.populateReports) {
+    const populatedReportsLoo = await loo.populate('reports').execPopulate();
+    res.status(200).json(populatedReportsLoo);
+    return;
+  }
+  console.log(loo);
   res.status(200).json(loo);
 });
 

--- a/packages/api/src/routes/search.js
+++ b/packages/api/src/routes/search.js
@@ -28,18 +28,18 @@ router.get('/', async (req, res) => {
     }
   }
 
-  // Delete handled keys.
-  delete params.text;
-  delete params.order;
-  delete params.to_date;
-  delete params.from_date;
-
   if (params.attributions) {
     query.$and = [];
     query.$and.push({
       attributions: { $all: [params.attributions] },
     });
   }
+
+  // Delete handled keys.
+  delete params.text;
+  delete params.order;
+  delete params.to_date;
+  delete params.from_date;
   delete params.attributions;
 
   // Arbitrary text searches have been removed until a way is found that is not


### PR DESCRIPTION
resolves: #348

* Adds two new components, LooTable & LooView.
  * LooTable displays properties attached to loos.
  * LooView displays information about specific loos.
    * LooView registers the /admin/loos/:loo path.
    * Displays report history using a bootstrap accordion.
* Modifies LooTile so it can be used outside of a GridList, also allows you to pass in multiple custom classes using the `classnames` lib.
* Adds a query param `?populateReports=true` to the /loos/:id endpoint on the API to require reports to be loaded.
* Refactors `search.js` in the API adding to code clarity.
* Includes a (hopeful (~_untested_~)) fix for the /admin routing issue
