### PR TITLE
392 second toilet appearing

### DIFF
--- a/packages/api/src/db/loo.js
+++ b/packages/api/src/db/loo.js
@@ -25,7 +25,7 @@ LooSchema.plugin(mongoosePaginate);
 /**
  * Create a Loo from a list of LooReports.
  */
-LooSchema.statics.fromReports = function(reports) {
+LooSchema.statics.fromReports = function(reports, idOverride) {
   // generate the loo from the sequence of diffs
   const properties = {};
   for (const rep of reports) {
@@ -53,8 +53,8 @@ LooSchema.statics.fromReports = function(reports) {
       return 0;
     });
 
-  // Calculate the persistent id for this loo from the first of its reports
-  const id = reports[0].suggestLooId();
+  // Use id given or calculate a persistent id for this loo from the first of its reports
+  const id = idOverride || reports[0].suggestLooId();
 
   // "this" refers to our static model
   return new this({

--- a/packages/api/src/db/report.js
+++ b/packages/api/src/db/report.js
@@ -110,6 +110,7 @@ ReportSchema.methods.unroll = async function() {
 };
 
 ReportSchema.methods.generateLoo = async function(idOverride) {
+  idOverride = idOverride || null;
   let looroll = await this.unroll();
   let loo = this.model('NewLoo').fromReports(looroll, idOverride);
   return loo;


### PR DESCRIPTION
* Loos generated from reports were solely relying upon ID generation when unrolling the loo roll (AKA Report List).
* I have modified this process so that if an ID is available it is used first, with the ID generation used as a fallback only if that is not available.