### PR TITLE
fix: conv str to null value so field removed in mongoose

### DIFF
--- a/packages/ui/src/pages/AddEditPage.js
+++ b/packages/ui/src/pages/AddEditPage.js
@@ -199,6 +199,11 @@ class AddEditPage extends Component {
       coordinates: [this.getCenter().lng, this.getCenter().lat],
     };
 
+    // Set questionnaire options to null before transport.
+    this.questionnaireMap.forEach(q => {
+      if (changes[q.property] === '') changes[q.property] = null;
+    });
+
     this.props.actionReportRequest(
       changes,
       this.isDerived() ? this.props.loo : undefined


### PR DESCRIPTION
* This ensures that all questionnaire values are converted into a null value before being sent to the backend if the user chooses to remove the value.