### PR TITLE
feat: disable save button when preferences haven't been changed

### DIFF
--- a/packages/ui/src/pages/PreferencesPage.js
+++ b/packages/ui/src/pages/PreferencesPage.js
@@ -105,6 +105,10 @@ class PreferencesPage extends Component {
     });
   }
 
+  isDirty() {
+    return Object.keys(this.state.unsavedPreferences).length !== 0;
+  }
+
   renderMain() {
     return (
       <div>
@@ -160,7 +164,11 @@ class PreferencesPage extends Component {
           </Notification>
         )}
 
-        <button className={controls.btn} onClick={this.save}>
+        <button
+          className={controls.btn}
+          onClick={this.save}
+          disabled={!this.isDirty()}
+        >
           Save
         </button>
       </div>


### PR DESCRIPTION
Fixes #394.

This disables the 'save' button when the preferences haven't yet been changed. It is also disabled upon saving.

It looks like this:

![Screenshot_2019-07-24 The Great British Public Toilet Map](https://user-images.githubusercontent.com/8274049/61797014-81b6bf00-ae1e-11e9-9d59-66dcd92c692a.png)


![Screenshot_2019-07-24 The Great British Public Toilet Map(1)](https://user-images.githubusercontent.com/8274049/61797012-811e2880-ae1e-11e9-8c33-7e6d749c61c9.png)

![Screenshot_2019-07-24 The Great British Public Toilet Map(2)](https://user-images.githubusercontent.com/8274049/61797011-811e2880-ae1e-11e9-9e3b-adf413fcab90.png)