### PR TITLE
fix: adding missing adobe javascript

### DIFF
--- a/packages/ui/public/adobe-prelaunch-script.js
+++ b/packages/ui/public/adobe-prelaunch-script.js
@@ -1,0 +1,18 @@
+/* eslint-disable */
+(function(g, b, d, f) {
+  (function(a, c, d) {
+    if (a) {
+      var e = b.createElement('style');
+      e.id = c;
+      e.innerHTML = d;
+      a.appendChild(e);
+    }
+  })(b.getElementsByTagName('head')[0], 'at-body-style', d);
+  setTimeout(function() {
+    var a = b.getElementsByTagName('head')[0];
+    if (a) {
+      var c = b.getElementById('at-body-style');
+      c && a.removeChild(c);
+    }
+  }, f);
+})(window, document, 'body {opacity: 0 !important}', 3e3);

--- a/packages/ui/src/components/Tracking/AdobeTracking.js
+++ b/packages/ui/src/components/Tracking/AdobeTracking.js
@@ -6,6 +6,7 @@ import config from '../../config';
 
 export const Staging = () => (
   <Helmet>
+    <script src={`${process.env.PUBLIC_URL}/adobe-prelaunch-script.js`} />
     <script src={`${process.env.PUBLIC_URL}/adobe-digital-data.js`} />
     <script
       src="//assets.adobedtm.com/launch-EN896f27c113614ed9a3a705dc289c6887-staging.min.js"
@@ -16,6 +17,7 @@ export const Staging = () => (
 
 export const Production = () => (
   <Helmet>
+    <script src={`${process.env.PUBLIC_URL}/adobe-prelaunch-script.js`} />
     <script src={`${process.env.PUBLIC_URL}/adobe-digital-data.js`} />
     <script
       src="//assets.adobedtm.com/launch-EN896f27c113614ed9a3a705dc289c6887-staging.min.js"


### PR DESCRIPTION
The Adobe documentation says to add this extra JS, from what I can tell it just hides the whole web page for 3 seconds? It's pretty gross, I don't recommend we merge this unless absolutely necessary. 