### PR TITLE
Update README.md to change git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This documentation is oriented towards developers, if you'd like to learn more a
 ### Installation
 
 ```
-git clone git@github.com:neontribe/gbptm.git gbptm
+git clone https://github.com/neontribe/gbptm.git gbptm
 cd gbptm
 nvm install && nvm use
 npm install -g yarn


### PR DESCRIPTION
Currently, if git isn't setup for ssh you'll get 
```
Cloning into 'gbptm'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
As the repo is public, we don't need access via ssh so we can fetch over https.

