### PR TITLE
443 dynamic tracking for adobe

### DIFF
--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -77,10 +77,12 @@ sagaMiddleware.run(mapControlsSaga);
 // Set a function to be called on location change
 history.listen(function(location) {
   // If we havn't opted in, we shouldn't have digitalData on window
-  if (window.hasOwnProperty('digitalData')) {
+  if (window.hasOwnProperty('digitalData') && window.hasOwnProperty('s')) {
     // does not include
     window.digitalData.page.pageInfo.pageName = `${document.title}`;
-    window.digitalData.page.pageInfo.destinationURL = `${window.location.href}`;
+    window.digitalData.page.attributes.contentType = '200';
+    // Fire a track (I know...)
+    window.s.t();
   }
 });
 

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -79,7 +79,7 @@ history.listen(function(location) {
   // If we havn't opted in, we shouldn't have digitalData on window
   if (window.hasOwnProperty('digitalData')) {
     // does not include
-    window.digitalData.page.pageInfo.pageName = `${location.pathname}`;
+    window.digitalData.page.pageInfo.pageName = `${document.title}`;
     window.digitalData.page.pageInfo.destinationURL = `${window.location.href}`;
   }
 });

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -74,6 +74,16 @@ sagaMiddleware.run(geolocationSaga);
 sagaMiddleware.run(makeLoosSaga(auth));
 sagaMiddleware.run(mapControlsSaga);
 
+// Set a function to be called on location change
+history.listen(function(location) {
+  // If we havn't opted in, we shouldn't have digitalData on window
+  if (window.hasOwnProperty('digitalData')) {
+    // does not include
+    window.digitalData.page.pageInfo.pageName = `${location.pathname}`;
+    window.digitalData.page.pageInfo.destinationURL = `${window.location.href}`;
+  }
+});
+
 // Create an enhanced history that syncs navigation events with the store
 
 if (typeof document !== 'undefined') {


### PR DESCRIPTION
As per https://github.com/neontribe/gbptm/issues/443

found a spot to try setting a listener on the history.
Pros:
- does notice a page change
- does fill the `window.digtalData` variable if it's there

Cons
- won't trigger on page _load_
- can't actually tell if it's being sent to adobe. :man_shrugging: can someone check that?
