### PR TITLE
fix: improve removal ux

### DIFF
--- a/packages/ui/src/css/controls.module.css
+++ b/packages/ui/src/css/controls.module.css
@@ -82,6 +82,12 @@
   cursor: not-allowed;
 }
 
+.textArea {
+  composes: text;
+  min-height: 100px;
+  resize: vertical;
+}
+
 .dropdown {
   composes: text;
 }

--- a/packages/ui/src/css/messages.module.css
+++ b/packages/ui/src/css/messages.module.css
@@ -1,7 +1,6 @@
 .message {
-  padding: 0.5rem;
+  padding: 1rem;
   margin-bottom: 1rem;
-  text-align: center;
 }
 
 .message p:last-child {

--- a/packages/ui/src/pages/AddEditPage.js
+++ b/packages/ui/src/pages/AddEditPage.js
@@ -555,7 +555,7 @@ const AddEditPage = function (props) {
   const renderMap = () => {
     return (
       <NearestLooMap
-        loo={looData ? looData.loo : null}
+        activeLoo={looData ? looData.loo : null}
         highlight={props.match.params.id}
         mapProps={{
           showLocation: false,
@@ -586,6 +586,11 @@ const AddEditPage = function (props) {
         map={<Loading message={'Error fetching toilet data'} />}
       />
     );
+  }
+
+  // Redirect to index if loo is not active (i.e. removed)
+  if (!looData.loo.active) {
+    history.push(`/`);
   }
 
   return <PageLayout main={renderMain()} map={renderMap()} />;

--- a/packages/ui/src/pages/LooPage.js
+++ b/packages/ui/src/pages/LooPage.js
@@ -9,6 +9,7 @@ import Loading from '../components/Loading';
 import PreferenceIndicators from '../components/PreferenceIndicators';
 import NearestLooMap from '../components/NearestLooMap';
 import DismissableBox from '../components/DismissableBox';
+import Notification from '../components/Notification';
 
 import styles from './css/loo-page.module.css';
 import layout from '../components/css/layout.module.css';
@@ -82,6 +83,7 @@ const LooPage = function LooPage(props) {
     'toObject',
     'updatedAt',
     'createdAt',
+    'removalReason',
     'id',
     '__typename',
   ];
@@ -136,22 +138,26 @@ const LooPage = function LooPage(props) {
             </button>
           )}
 
-          <a
-            href={
-              'https://maps.apple.com/?dirflg=w&daddr=' +
-              [loo.location.lat, loo.location.lng]
-            }
-            className={controls.btn}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Get Directions
-          </a>
+          {loo.active && (
+            <>
+              <a
+                href={
+                  'https://maps.apple.com/?dirflg=w&daddr=' +
+                  [loo.location.lat, loo.location.lng]
+                }
+                className={controls.btn}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Get Directions
+              </a>
 
-          {config.allowAddEditLoo && (
-            <Link to={`/loos/${loo.id}/edit`} className={controls.btn}>
-              Edit toilet
-            </Link>
+              {config.allowAddEditLoo && (
+                <Link to={`/loos/${loo.id}/edit`} className={controls.btn}>
+                  Edit toilet
+                </Link>
+              )}
+            </>
           )}
         </div>
 
@@ -183,6 +189,15 @@ const LooPage = function LooPage(props) {
               </>
             }
           />
+        )}
+
+        {!loo.active && (
+          <Notification>
+            <b>This toilet has been removed.</b>
+            {loo.removalReason && (
+              <div>Removal reason: "{loo.removalReason}"</div>
+            )}
+          </Notification>
         )}
 
         <h2 className={headings.large}>{loo.name || 'Toilet'}</h2>
@@ -239,7 +254,7 @@ const LooPage = function LooPage(props) {
   function renderMap() {
     return (
       <NearestLooMap
-        loo={data.loo}
+        activeLoo={data.loo}
         mapProps={{
           showLocation: false,
           showSearchControl: true,

--- a/packages/ui/src/pages/RemovePage.js
+++ b/packages/ui/src/pages/RemovePage.js
@@ -4,6 +4,7 @@ import { useQuery, useMutation } from '@apollo/client';
 import { loader } from 'graphql.macro';
 
 import config from '../config';
+import history from '../history';
 
 import PageLayout from '../components/PageLayout';
 import Loading from '../components/Loading';
@@ -13,7 +14,7 @@ import layout from '../components/css/layout.module.css';
 import headings from '../css/headings.module.css';
 import controls from '../css/controls.module.css';
 
-const FIND_LOO_BY_ID = loader('./findLooLocationById.graphql');
+const FIND_LOO_BY_ID = loader('./findLooById.graphql');
 const REMOVE_LOO_MUTATION = loader('./removeLoo.graphql');
 
 const RemovePage = function (props) {
@@ -33,7 +34,7 @@ const RemovePage = function (props) {
     { loading: loadingRemove, error: removeError },
   ] = useMutation(REMOVE_LOO_MUTATION, {
     onCompleted: () => {
-      props.history.push('/');
+      props.history.push(`/loos/${props.match.params.id}/thanks`);
     },
   });
 
@@ -41,7 +42,9 @@ const RemovePage = function (props) {
     setReason(evt.currentTarget.value);
   };
 
-  const doSubmit = () => {
+  const doSubmit = (e) => {
+    e.preventDefault();
+
     doRemove({
       variables: {
         id: looData.loo.id,
@@ -53,14 +56,12 @@ const RemovePage = function (props) {
   const renderMain = () => {
     return (
       <div>
-        <div>
-          <div className={layout.controls}>
-            {config.showBackButtons && (
-              <button onClick={props.history.goBack} className={controls.btn}>
-                Back
-              </button>
-            )}
-          </div>
+        <div className={layout.controls}>
+          {config.showBackButtons && (
+            <button onClick={props.history.goBack} className={controls.btn}>
+              Back
+            </button>
+          )}
         </div>
 
         <h2 className={headings.large}>Toilet Remover</h2>
@@ -70,22 +71,27 @@ const RemovePage = function (props) {
           the form below.
         </p>
 
-        <label>
-          Reason for removal
-          <textarea
-            type="text"
-            name="reason"
-            className={controls.text}
-            value={reason}
-            onChange={updateReason}
-          />
-        </label>
+        <form onSubmit={doSubmit}>
+          <label>
+            Reason for removal
+            <textarea
+              type="text"
+              name="reason"
+              className={controls.textArea}
+              value={reason}
+              onChange={updateReason}
+              style={{ width: '100%' }}
+              required
+            />
+          </label>
 
-        <button onClick={doSubmit} className={controls.btnCaution}>
-          Remove it
-        </button>
+          <button type="submit" className={controls.btnCaution}>
+            Remove it
+          </button>
+        </form>
 
         {loadingRemove && <Loading message="Submitting removal report..." />}
+
         {removeError && (
           <Loading message="Oops. We can't submit your report at this time. Try again later." />
         )}
@@ -124,6 +130,13 @@ const RemovePage = function (props) {
       />
     );
   }
+
+  console.log(looData);
+
+  if (!looData.loo.active) {
+    history.push(`/`);
+  }
+
   return <PageLayout main={renderMain()} map={renderMap()} />;
 };
 

--- a/packages/ui/src/pages/findLooLocationById.graphql
+++ b/packages/ui/src/pages/findLooLocationById.graphql
@@ -1,9 +1,0 @@
-query findLooById($id: ID) {
-  loo(id: $id) {
-    id
-    location {
-      lat
-      lng
-    }
-  }
-}

--- a/packages/ui/src/pages/removeLoo.graphql
+++ b/packages/ui/src/pages/removeLoo.graphql
@@ -1,9 +1,11 @@
 mutation removeLoo($id: ID!, $reason: String!) {
-  submitRemovalReport(report: {
-    edit: $id,
-    reason: $reason
-  }) {
+  submitRemovalReport(report: { edit: $id, reason: $reason }) {
     code
     success
+    loo {
+      id
+      active
+      removalReason
+    }
   }
 }


### PR DESCRIPTION
This PR makes a number of improvements to the toilet removal process:

1. Makes the removal reason field required on the client
2. Adds a clearer message to the loos page for a removed loo
3. When a removal is complete, the user is directed to the removed loo page and shown a thank you message (as you would making any other edit)
4. When viewing a removed loo, a marker is shown on the map
5. When viewing a removed loo, the get directions and edit buttons are disabled
6. Trying to access the edit or removal route for a removed loo will redirect to the index route


<img width="1124" alt="Screenshot 2020-03-26 at 15 48 15" src="https://user-images.githubusercontent.com/53346/77666728-376f7a00-6f79-11ea-8975-6e3372a30576.png">

fixes #244 