### PR TITLE
refactor: manage EntryForm with react-hook-form

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-dom": "16.13.1",
     "react-ga": "2.7.0",
     "react-helmet": "6.0.0",
+    "react-hook-form": "5.6.0",
     "react-leaflet": "2.6.3",
     "react-responsive": "8.0.3",
     "react-router-dom": "5.1.2",

--- a/src/components/EntryForm.js
+++ b/src/components/EntryForm.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import MediaQuery from 'react-responsive';
+import { useForm } from 'react-hook-form';
+import isFunction from 'lodash/isFunction';
 
 import layout from '../components/css/layout.module.css';
 import styles from '../pages/css/edit-loo-page.module.css';
@@ -9,6 +11,7 @@ import headings from '../css/headings.module.css';
 import controls from '../css/controls.module.css';
 
 import config from '../config';
+import history from '../history';
 
 import Loading from '../components/Loading';
 import DismissableBox from './DismissableBox';
@@ -18,261 +21,292 @@ const EntryForm = ({
   map,
   loo,
   center,
-  handleChange,
-  handleTriStateChange,
+  questionnaireMap,
   optionsMap,
   saveResponse,
   saveError,
+  children,
   ...props
-}) => (
-  <form>
+}) => {
+  const { register, handleSubmit, formState } = useForm();
+
+  // read the formState before render to subscribe the form state through Proxy
+  const { dirtyFields } = formState;
+
+  const onSubmit = (data) => {
+    // transform questionnaire data
+    questionnaireMap.forEach((q) => {
+      const value = data[q.property];
+
+      if (value === 'true') {
+        data[q.property] = true;
+      } else if (value === 'false') {
+        data[q.property] = false;
+      } else if (value === '') {
+        data[q.property] = null;
+      }
+    });
+
+    props.onSubmit(data, dirtyFields);
+  };
+
+  return (
     <div>
       <div className={layout.controls}>
         {config.showBackButtons && (
-          <button onClick={props.history.goBack} className={controls.btn}>
+          <button
+            type="button"
+            onClick={history.goBack}
+            className={controls.btn}
+          >
             Back
           </button>
         )}
       </div>
-    </div>
 
-    <h2 className={headings.large}>Add This Toilet</h2>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <h2 className={headings.large}>Add This Toilet</h2>
 
-    <MediaQuery maxWidth={config.viewport.mobile}>
-      <div className={styles.mobileMap}>{map}</div>
-    </MediaQuery>
+        <MediaQuery maxWidth={config.viewport.mobile}>
+          <div className={styles.mobileMap}>{map}</div>
+        </MediaQuery>
 
-    <Notification>
-      <p>Align the crosshair with where you believe the toilet to be.</p>
-    </Notification>
-
-    <DismissableBox
-      persistKey="edit-welcome"
-      title="Welcome Contributor!"
-      content="Please fill in everything you can about the toilet below."
-    />
-
-    <label>
-      Toilet name
-      <input
-        name="name"
-        type="text"
-        className={controls.text}
-        value={loo.name === null ? '' : loo.name}
-        onChange={handleChange}
-        data-testid="toilet-name"
-      />
-    </label>
-
-    <label>
-      Who can access?
-      <select
-        name="access"
-        className={controls.dropdown}
-        value={loo.access === null ? '' : loo.access}
-        onChange={handleChange}
-        data-testid="who-can-access"
-      >
-        <option value="">Unknown</option>
-        {optionsMap.access.map((option, index) => (
-          <option key={index} value={option.value}>
-            {option.name}
-          </option>
-        ))}
-      </select>
-    </label>
-
-    <label>
-      Facilities
-      <select
-        name="type"
-        className={controls.dropdown}
-        value={loo.type === null ? '' : loo.type}
-        onChange={handleChange}
-        data-testid="facilities"
-      >
-        <option value="">Unknown</option>
-        {optionsMap.type.map((option, index) => (
-          <option key={index} value={option.value}>
-            {option.name}
-          </option>
-        ))}
-      </select>
-    </label>
-
-    <label>
-      Accessible facilities
-      <select
-        name="accessibleType"
-        className={controls.dropdown}
-        value={loo.accessibleType === null ? '' : loo.accessibleType}
-        onChange={handleChange}
-        data-testid="accessible-facilities"
-      >
-        <option value="">Unknown</option>
-        {optionsMap.type.map((option, index) => (
-          <option key={index} value={option.value}>
-            {option.name}
-          </option>
-        ))}
-      </select>
-    </label>
-
-    <label>
-      Opening hours
-      <select
-        name="opening"
-        className={controls.dropdown}
-        value={loo.opening === null ? '' : loo.opening}
-        onChange={handleChange}
-        data-testid="opening-hours"
-      >
-        <option value="">Unknown</option>
-        {optionsMap.opening.map((option, index) => (
-          <option key={index} value={option.value}>
-            {option.name}
-          </option>
-        ))}
-      </select>
-    </label>
-
-    <div className={styles.questionnaire}>
-      <div>
-        <span className={styles.questionnaireCol} />
-        <span className={styles.questionnaireCol} id="yes">
-          Yes
-        </span>
-        <span className={styles.questionnaireCol} id="no">
-          No
-        </span>
-        <span className={styles.questionnaireCol} id="unknown">
-          Don't know
-        </span>
-      </div>
-
-      {props.questionnaireMap.map((q, index) => (
-        <fieldset key={index} className={styles.questionnaireGroup}>
-          <legend className={helpers.visuallyHidden}>{q.question}</legend>
-          <span className={styles.questionnaireCol}>{q.question}</span>
-          <input
-            name={q.property}
-            className={styles.questionnaireCol}
-            type="radio"
-            value={true}
-            aria-labelledby="yes"
-            checked={loo[q.property] === true}
-            onChange={handleTriStateChange}
-            data-testid={`${q.property}:yes`}
-          />
-          <input
-            name={q.property}
-            className={styles.questionnaireCol}
-            type="radio"
-            value={false}
-            aria-labelledby="no"
-            checked={loo[q.property] === false}
-            onChange={handleTriStateChange}
-            data-testid={`${q.property}:no`}
-          />
-          <input
-            name={q.property}
-            className={styles.questionnaireCol}
-            type="radio"
-            value=""
-            aria-labelledby="unknown"
-            checked={loo[q.property] === ''}
-            onChange={handleTriStateChange}
-            data-testid={`${q.property}:unknown`}
-          />
-        </fieldset>
-      ))}
-    </div>
-
-    <label>
-      Fee?
-      <input
-        name="fee"
-        type="text"
-        className={controls.text}
-        value={loo.fee === null ? '' : loo.fee}
-        placeholder="The amount e.g. £0.10"
-        onChange={handleChange}
-        data-testid="fee"
-      />
-    </label>
-
-    <label>
-      Any notes?
-      <textarea
-        name="notes"
-        className={controls.text}
-        value={loo.notes === null ? '' : loo.notes}
-        onChange={handleChange}
-        data-testid="notes"
-      />
-    </label>
-
-    <h3 className={headings.regular}>Data for this toilet</h3>
-
-    <div className={styles.data}>
-      <label>
-        Latitude
-        <input
-          type="text"
-          name="geometry.coordinates.0"
-          className={controls.text}
-          value={center.lat}
-          readOnly={true}
-        />
-      </label>
-
-      <label>
-        Longitude
-        <input
-          type="text"
-          name="geometry.coordinates.1"
-          className={controls.text}
-          data-testid="loo-name"
-          value={center.lng}
-          readOnly={true}
-        />
-      </label>
-    </div>
-
-    {props.saveLoading && <Loading message="Saving your changes..." />}
-
-    {
-      // This message probably won't be seen, but just in case the redirect fails...
-      saveResponse && saveResponse.submitReport.code === '200' && (
         <Notification>
-          Successfully saved changes! Redirecting&hellip;
+          <p>Align the crosshair with where you believe the toilet to be.</p>
         </Notification>
-      )
-    }
 
-    {
-      // TODO better error message?
-      (saveError ||
-        (saveResponse && saveResponse.submitReport.code !== '200')) && (
-        <Notification>
-          Oops, there was an error saving your changes.
-          {console.log(saveError, saveResponse)}
-        </Notification>
-      )
-    }
+        <DismissableBox
+          persistKey="edit-welcome"
+          title="Welcome Contributor!"
+          content="Please fill in everything you can about the toilet below."
+        />
 
-    <div className={controls.btnStack}>
-      {props.actions.map((action, index) => (
-        <React.Fragment key={index} children={action} />
-      ))}
+        <label>
+          Toilet name
+          <input
+            ref={register}
+            name="name"
+            type="text"
+            className={controls.text}
+            defaultValue={loo.name === null ? '' : loo.name}
+            data-testid="toilet-name"
+          />
+        </label>
+
+        <label>
+          Who can access?
+          <select
+            ref={register}
+            name="access"
+            className={controls.dropdown}
+            defaultValue={loo.access === null ? '' : loo.access}
+            data-testid="who-can-access"
+          >
+            <option value="">Unknown</option>
+            {optionsMap.access.map((option, index) => (
+              <option key={index} value={option.value}>
+                {option.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Facilities
+          <select
+            ref={register}
+            name="type"
+            className={controls.dropdown}
+            defaultValue={loo.type === null ? '' : loo.type}
+            data-testid="facilities"
+          >
+            <option value="">Unknown</option>
+            {optionsMap.type.map((option, index) => (
+              <option key={index} value={option.value}>
+                {option.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Accessible facilities
+          <select
+            ref={register}
+            name="accessibleType"
+            className={controls.dropdown}
+            defaultValue={loo.accessibleType === null ? '' : loo.accessibleType}
+            data-testid="accessible-facilities"
+          >
+            <option value="">Unknown</option>
+            {optionsMap.type.map((option, index) => (
+              <option key={index} value={option.value}>
+                {option.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Opening hours
+          <select
+            ref={register}
+            name="opening"
+            className={controls.dropdown}
+            defaultValue={loo.opening === null ? '' : loo.opening}
+            data-testid="opening-hours"
+          >
+            <option value="">Unknown</option>
+            {optionsMap.opening.map((option, index) => (
+              <option key={index} value={option.value}>
+                {option.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className={styles.questionnaire}>
+          <div>
+            <span className={styles.questionnaireCol} />
+            <span className={styles.questionnaireCol} id="yes">
+              Yes
+            </span>
+            <span className={styles.questionnaireCol} id="no">
+              No
+            </span>
+            <span className={styles.questionnaireCol} id="unknown">
+              Don't know
+            </span>
+          </div>
+
+          {questionnaireMap.map((q, index) => (
+            <fieldset key={index} className={styles.questionnaireGroup}>
+              <legend className={helpers.visuallyHidden}>{q.question}</legend>
+
+              <span className={styles.questionnaireCol}>{q.question}</span>
+
+              <input
+                ref={register}
+                name={q.property}
+                className={styles.questionnaireCol}
+                type="radio"
+                value={true}
+                aria-labelledby="yes"
+                defaultChecked={loo[q.property] === true}
+                data-testid={`${q.property}:yes`}
+              />
+
+              <input
+                ref={register}
+                name={q.property}
+                className={styles.questionnaireCol}
+                type="radio"
+                value={false}
+                aria-labelledby="no"
+                defaultChecked={loo[q.property] === false}
+                data-testid={`${q.property}:no`}
+              />
+
+              <input
+                ref={register}
+                name={q.property}
+                className={styles.questionnaireCol}
+                type="radio"
+                value=""
+                aria-labelledby="unknown"
+                defaultChecked={loo[q.property] === ''}
+                data-testid={`${q.property}:unknown`}
+              />
+            </fieldset>
+          ))}
+        </div>
+
+        <label>
+          Fee?
+          <input
+            ref={register}
+            name="fee"
+            type="text"
+            className={controls.text}
+            defaultValue={loo.fee === null ? '' : loo.fee}
+            placeholder="The amount e.g. £0.10"
+            data-testid="fee"
+          />
+        </label>
+
+        <label>
+          Any notes?
+          <textarea
+            ref={register}
+            name="notes"
+            className={controls.text}
+            defaultValue={loo.notes === null ? '' : loo.notes}
+            data-testid="notes"
+          />
+        </label>
+
+        <h3 className={headings.regular}>Data for this toilet</h3>
+
+        <div className={styles.data}>
+          <label>
+            Latitude
+            <input
+              ref={register}
+              type="text"
+              name="geometry.coordinates.0"
+              className={controls.text}
+              defaultValue={center.lat}
+              readOnly={true}
+            />
+          </label>
+
+          <label>
+            Longitude
+            <input
+              ref={register}
+              type="text"
+              name="geometry.coordinates.1"
+              className={controls.text}
+              data-testid="loo-name"
+              defaultValue={center.lng}
+              readOnly={true}
+            />
+          </label>
+        </div>
+
+        {props.saveLoading && <Loading message="Saving your changes..." />}
+
+        {
+          // This message probably won't be seen, but just in case the redirect fails...
+          saveResponse && saveResponse.submitReport.code === '200' && (
+            <Notification>
+              Successfully saved changes! Redirecting&hellip;
+            </Notification>
+          )
+        }
+
+        {
+          // TODO better error message?
+          (saveError ||
+            (saveResponse && saveResponse.submitReport.code !== '200')) && (
+            <Notification>
+              Oops, there was an error saving your changes.
+              {console.log(saveError, saveResponse)}
+            </Notification>
+          )
+        }
+
+        <div className={controls.btnStack}>
+          {isFunction(children) ? children({ dirtyFields }) : children}
+        </div>
+      </form>
     </div>
-  </form>
-);
+  );
+};
 
 EntryForm.propTypes = {
   map: PropTypes.element.isRequired,
-  handleChange: PropTypes.func.isRequired,
-  handleTriStateChange: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
   loo: PropTypes.shape({
     name: PropTypes.string,
     access: PropTypes.string,

--- a/src/components/EntryForm.js
+++ b/src/components/EntryForm.js
@@ -104,7 +104,7 @@ const EntryForm = ({
             name="name"
             type="text"
             className={controls.text}
-            defaultValue={loo.name === null ? '' : loo.name}
+            defaultValue={loo.name || ''}
             data-testid="toilet-name"
           />
         </label>
@@ -115,7 +115,7 @@ const EntryForm = ({
             ref={register}
             name="access"
             className={controls.dropdown}
-            defaultValue={loo.access === null ? '' : loo.access}
+            defaultValue={loo.access || ''}
             data-testid="who-can-access"
           >
             <option value="">Unknown</option>
@@ -133,7 +133,7 @@ const EntryForm = ({
             ref={register}
             name="type"
             className={controls.dropdown}
-            defaultValue={loo.type === null ? '' : loo.type}
+            defaultValue={loo.type || ''}
             data-testid="facilities"
           >
             <option value="">Unknown</option>
@@ -151,7 +151,7 @@ const EntryForm = ({
             ref={register}
             name="accessibleType"
             className={controls.dropdown}
-            defaultValue={loo.accessibleType === null ? '' : loo.accessibleType}
+            defaultValue={loo.accessibleType || ''}
             data-testid="accessible-facilities"
           >
             <option value="">Unknown</option>
@@ -169,7 +169,7 @@ const EntryForm = ({
             ref={register}
             name="opening"
             className={controls.dropdown}
-            defaultValue={loo.opening === null ? '' : loo.opening}
+            defaultValue={loo.opening || ''}
             data-testid="opening-hours"
           >
             <option value="">Unknown</option>
@@ -244,7 +244,7 @@ const EntryForm = ({
             name="fee"
             type="text"
             className={controls.text}
-            defaultValue={loo.fee === null ? '' : loo.fee}
+            defaultValue={loo.fee || ''}
             placeholder="The amount e.g. £0.10"
             data-testid="fee"
           />
@@ -256,7 +256,7 @@ const EntryForm = ({
             ref={register}
             name="notes"
             className={controls.text}
-            defaultValue={loo.notes === null ? '' : loo.notes}
+            defaultValue={loo.notes || ''}
             data-testid="notes"
           />
         </label>

--- a/src/components/EntryForm.js
+++ b/src/components/EntryForm.js
@@ -1,0 +1,325 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import MediaQuery from 'react-responsive';
+
+import layout from '../components/css/layout.module.css';
+import styles from '../pages/css/edit-loo-page.module.css';
+import helpers from '../css/helpers.module.css';
+import headings from '../css/headings.module.css';
+import controls from '../css/controls.module.css';
+
+import config from '../config';
+
+import Loading from '../components/Loading';
+import DismissableBox from './DismissableBox';
+import Notification from './Notification';
+
+const EntryForm = ({
+  map,
+  loo,
+  center,
+  handleChange,
+  handleTriStateChange,
+  optionsMap,
+  saveResponse,
+  saveError,
+  ...props
+}) => (
+  <form>
+    <div>
+      <div className={layout.controls}>
+        {config.showBackButtons && (
+          <button onClick={props.history.goBack} className={controls.btn}>
+            Back
+          </button>
+        )}
+      </div>
+    </div>
+
+    <h2 className={headings.large}>Add This Toilet</h2>
+
+    <MediaQuery maxWidth={config.viewport.mobile}>
+      <div className={styles.mobileMap}>{map}</div>
+    </MediaQuery>
+
+    <Notification>
+      <p>Align the crosshair with where you believe the toilet to be.</p>
+    </Notification>
+
+    <DismissableBox
+      persistKey="edit-welcome"
+      title="Welcome Contributor!"
+      content="Please fill in everything you can about the toilet below."
+    />
+
+    <label>
+      Toilet name
+      <input
+        name="name"
+        type="text"
+        className={controls.text}
+        value={loo.name === null ? '' : loo.name}
+        onChange={handleChange}
+        data-testid="toilet-name"
+      />
+    </label>
+
+    <label>
+      Who can access?
+      <select
+        name="access"
+        className={controls.dropdown}
+        value={loo.access === null ? '' : loo.access}
+        onChange={handleChange}
+        data-testid="who-can-access"
+      >
+        <option value="">Unknown</option>
+        {optionsMap.access.map((option, index) => (
+          <option key={index} value={option.value}>
+            {option.name}
+          </option>
+        ))}
+      </select>
+    </label>
+
+    <label>
+      Facilities
+      <select
+        name="type"
+        className={controls.dropdown}
+        value={loo.type === null ? '' : loo.type}
+        onChange={handleChange}
+        data-testid="facilities"
+      >
+        <option value="">Unknown</option>
+        {optionsMap.type.map((option, index) => (
+          <option key={index} value={option.value}>
+            {option.name}
+          </option>
+        ))}
+      </select>
+    </label>
+
+    <label>
+      Accessible facilities
+      <select
+        name="accessibleType"
+        className={controls.dropdown}
+        value={loo.accessibleType === null ? '' : loo.accessibleType}
+        onChange={handleChange}
+        data-testid="accessible-facilities"
+      >
+        <option value="">Unknown</option>
+        {optionsMap.type.map((option, index) => (
+          <option key={index} value={option.value}>
+            {option.name}
+          </option>
+        ))}
+      </select>
+    </label>
+
+    <label>
+      Opening hours
+      <select
+        name="opening"
+        className={controls.dropdown}
+        value={loo.opening === null ? '' : loo.opening}
+        onChange={handleChange}
+        data-testid="opening-hours"
+      >
+        <option value="">Unknown</option>
+        {optionsMap.opening.map((option, index) => (
+          <option key={index} value={option.value}>
+            {option.name}
+          </option>
+        ))}
+      </select>
+    </label>
+
+    <div className={styles.questionnaire}>
+      <div>
+        <span className={styles.questionnaireCol} />
+        <span className={styles.questionnaireCol} id="yes">
+          Yes
+        </span>
+        <span className={styles.questionnaireCol} id="no">
+          No
+        </span>
+        <span className={styles.questionnaireCol} id="unknown">
+          Don't know
+        </span>
+      </div>
+
+      {props.questionnaireMap.map((q, index) => (
+        <fieldset key={index} className={styles.questionnaireGroup}>
+          <legend className={helpers.visuallyHidden}>{q.question}</legend>
+          <span className={styles.questionnaireCol}>{q.question}</span>
+          <input
+            name={q.property}
+            className={styles.questionnaireCol}
+            type="radio"
+            value={true}
+            aria-labelledby="yes"
+            checked={loo[q.property] === true}
+            onChange={handleTriStateChange}
+            data-testid={`${q.property}:yes`}
+          />
+          <input
+            name={q.property}
+            className={styles.questionnaireCol}
+            type="radio"
+            value={false}
+            aria-labelledby="no"
+            checked={loo[q.property] === false}
+            onChange={handleTriStateChange}
+            data-testid={`${q.property}:no`}
+          />
+          <input
+            name={q.property}
+            className={styles.questionnaireCol}
+            type="radio"
+            value=""
+            aria-labelledby="unknown"
+            checked={loo[q.property] === ''}
+            onChange={handleTriStateChange}
+            data-testid={`${q.property}:unknown`}
+          />
+        </fieldset>
+      ))}
+    </div>
+
+    <label>
+      Fee?
+      <input
+        name="fee"
+        type="text"
+        className={controls.text}
+        value={loo.fee === null ? '' : loo.fee}
+        placeholder="The amount e.g. £0.10"
+        onChange={handleChange}
+        data-testid="fee"
+      />
+    </label>
+
+    <label>
+      Any notes?
+      <textarea
+        name="notes"
+        className={controls.text}
+        value={loo.notes === null ? '' : loo.notes}
+        onChange={handleChange}
+        data-testid="notes"
+      />
+    </label>
+
+    <h3 className={headings.regular}>Data for this toilet</h3>
+
+    <div className={styles.data}>
+      <label>
+        Latitude
+        <input
+          type="text"
+          name="geometry.coordinates.0"
+          className={controls.text}
+          value={center.lat}
+          readOnly={true}
+        />
+      </label>
+
+      <label>
+        Longitude
+        <input
+          type="text"
+          name="geometry.coordinates.1"
+          className={controls.text}
+          data-testid="loo-name"
+          value={center.lng}
+          readOnly={true}
+        />
+      </label>
+    </div>
+
+    {props.saveLoading && <Loading message="Saving your changes..." />}
+
+    {
+      // This message probably won't be seen, but just in case the redirect fails...
+      saveResponse && saveResponse.submitReport.code === '200' && (
+        <Notification>
+          Successfully saved changes! Redirecting&hellip;
+        </Notification>
+      )
+    }
+
+    {
+      // TODO better error message?
+      (saveError ||
+        (saveResponse && saveResponse.submitReport.code !== '200')) && (
+        <Notification>
+          Oops, there was an error saving your changes.
+          {console.log(saveError, saveResponse)}
+        </Notification>
+      )
+    }
+
+    <div className={controls.btnStack}>
+      {props.actions.map((action, index) => (
+        <React.Fragment key={index} children={action} />
+      ))}
+    </div>
+  </form>
+);
+
+EntryForm.propTypes = {
+  map: PropTypes.element.isRequired,
+  handleChange: PropTypes.func.isRequired,
+  handleTriStateChange: PropTypes.func.isRequired,
+  loo: PropTypes.shape({
+    name: PropTypes.string,
+    access: PropTypes.string,
+    type: PropTypes.string,
+    accessibleType: PropTypes.string,
+    opening: PropTypes.string,
+    fee: PropTypes.string,
+    notes: PropTypes.string,
+  }),
+  center: PropTypes.shape({
+    lat: PropTypes.number.isRequired,
+    lng: PropTypes.number.isRequired,
+  }).isRequired,
+  optionsMap: PropTypes.shape({
+    access: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        value: PropTypes.string,
+      })
+    ).isRequired,
+    type: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        value: PropTypes.string,
+      })
+    ).isRequired,
+    opening: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        value: PropTypes.string,
+      })
+    ).isRequired,
+  }).isRequired,
+  questionnaireMap: PropTypes.arrayOf(
+    PropTypes.shape({
+      question: PropTypes.string.isRequired,
+      property: PropTypes.string.isRequired,
+    })
+  ),
+  saveLoading: PropTypes.bool,
+  saveError: PropTypes.func,
+  saveResponse: PropTypes.func,
+};
+
+EntryForm.defaultProps = {
+  loo: {},
+  questionnaireMap: [],
+};
+
+export default EntryForm;

--- a/src/components/EntryForm.js
+++ b/src/components/EntryForm.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import MediaQuery from 'react-responsive';
 import { useForm } from 'react-hook-form';
 import isFunction from 'lodash/isFunction';
+import omit from 'lodash/omit';
 
 import layout from '../components/css/layout.module.css';
 import styles from '../pages/css/edit-loo-page.module.css';
@@ -28,7 +29,7 @@ const EntryForm = ({
   children,
   ...props
 }) => {
-  const { register, handleSubmit, formState } = useForm();
+  const { register, handleSubmit, formState, setValue } = useForm();
 
   // read the formState before render to subscribe the form state through Proxy
   const { dirtyFields } = formState;
@@ -47,8 +48,23 @@ const EntryForm = ({
       }
     });
 
+    // map geometry data to expected structure
+    data.location = {
+      lat: parseFloat(data.geometry.coordinates[0]),
+      lng: parseFloat(data.geometry.coordinates[1]),
+    };
+
+    data = omit(data, 'geometry');
+
     props.onSubmit(data, dirtyFields);
   };
+
+  useEffect(() => {
+    // readonly fields won't fire a change event
+    // setValue ensures that the fields will be marked as dirty
+    setValue('geometry.coordinates.0', center.lat);
+    setValue('geometry.coordinates.1', center.lng);
+  }, [center, setValue]);
 
   return (
     <div>
@@ -255,8 +271,8 @@ const EntryForm = ({
               type="text"
               name="geometry.coordinates.0"
               className={controls.text}
-              defaultValue={center.lat}
-              readOnly={true}
+              value={center.lat}
+              readOnly
             />
           </label>
 
@@ -268,8 +284,8 @@ const EntryForm = ({
               name="geometry.coordinates.1"
               className={controls.text}
               data-testid="loo-name"
-              defaultValue={center.lng}
-              readOnly={true}
+              value={center.lng}
+              readOnly
             />
           </label>
         </div>
@@ -347,8 +363,8 @@ EntryForm.propTypes = {
     })
   ),
   saveLoading: PropTypes.bool,
-  saveError: PropTypes.func,
-  saveResponse: PropTypes.func,
+  saveError: PropTypes.object,
+  saveResponse: PropTypes.object,
 };
 
 EntryForm.defaultProps = {

--- a/src/pages/AddPage.js
+++ b/src/pages/AddPage.js
@@ -78,19 +78,12 @@ const AddPage = (props) => {
     // add the active state for which there's no user-facing form control as yet
     data.active = true;
 
-    // always associate geometry with a report, even if unchanged
-    // omits __typename
-    data.location = {
-      lat: mapPosition.center.lat,
-      lng: mapPosition.center.lng,
-    };
-
     updateLoo({
       variables: data,
     });
   };
 
-  const MapFragment = () => (
+  const mapFragment = (
     <LooMap
       loos={data}
       center={mapPosition.center}
@@ -101,9 +94,9 @@ const AddPage = (props) => {
     />
   );
 
-  const MainFragment = () => (
+  const mainFragment = (
     <EntryForm
-      map={<MapFragment />}
+      map={mapFragment}
       loo={getInitialFormState()}
       center={mapPosition.center}
       questionnaireMap={questionnaireMap}
@@ -122,7 +115,7 @@ const AddPage = (props) => {
     </EntryForm>
   );
 
-  return <PageLayout main={<MainFragment />} map={<MapFragment />} />;
+  return <PageLayout main={mainFragment} map={mapFragment} />;
 };
 
 export default AddPage;

--- a/src/pages/AddPage.js
+++ b/src/pages/AddPage.js
@@ -1,22 +1,15 @@
 import React, { useState } from 'react';
 import { PropTypes } from 'prop-types';
 
-import MediaQuery from 'react-responsive';
 import queryString from 'query-string';
 
 import PageLayout from '../components/PageLayout';
-import Loading from '../components/Loading';
 import LooMap from '../components/LooMap';
-import DismissableBox from '../components/DismissableBox';
-import Notification from '../components/Notification';
+import EntryForm from '../components/EntryForm';
 
 import config from '../config';
 import graphqlMappings from '../graphqlMappings';
 
-import styles from './css/edit-loo-page.module.css';
-import layout from '../components/css/layout.module.css';
-import helpers from '../css/helpers.module.css';
-import headings from '../css/headings.module.css';
 import controls from '../css/controls.module.css';
 
 import { useMutation } from '@apollo/client';
@@ -151,7 +144,9 @@ const AddPage = (props) => {
 
     // Set questionnaire options to null before transport.
     questionnaireMap.forEach((q) => {
-      if (changes[q.property] === '') changes[q.property] = null;
+      if (changes[q.property] === '') {
+        changes[q.property] = null;
+      }
     });
 
     updateLoo({
@@ -159,274 +154,42 @@ const AddPage = (props) => {
     });
   };
 
-  const renderMain = () => {
-    const loo = looState;
-    const center = mapPosition.center;
+  const MapFragment = () => (
+    <LooMap
+      loos={data}
+      center={mapPosition.center}
+      minZoom={config.editMinZoom}
+      onMoveEnd={setMapPosition}
+      showCenter
+      showSearchControl
+    />
+  );
 
-    return (
-      <div>
-        <div>
-          <div className={layout.controls}>
-            {config.showBackButtons && (
-              <button onClick={props.history.goBack} className={controls.btn}>
-                Back
-              </button>
-            )}
-          </div>
-        </div>
+  const MainFragment = () => (
+    <EntryForm
+      map={<MapFragment />}
+      loo={looState}
+      center={mapPosition.center}
+      handleChange={handleChange}
+      handleTriStateChange={handleTriStateChange}
+      questionnaireMap={questionnaireMap}
+      saveLoading={saveLoading}
+      saveResponse={saveResponse}
+      saveError={saveError}
+      optionsMap={optionsMap}
+      actions={[
+        <input
+          type="submit"
+          className={controls.btn}
+          onClick={save}
+          value="Add the toilet"
+          data-testid="add-the-toilet"
+        />,
+      ]}
+    />
+  );
 
-        <h2 className={headings.large}>Add This Toilet</h2>
-
-        <MediaQuery maxWidth={config.viewport.mobile}>
-          <div className={styles.mobileMap}>{renderMap()}</div>
-        </MediaQuery>
-
-        <Notification>
-          <p>Align the crosshair with where you believe the toilet to be.</p>
-        </Notification>
-
-        <DismissableBox
-          persistKey="edit-welcome"
-          title="Welcome Contributor!"
-          content="Please fill in everything you can about the toilet below."
-        />
-
-        <label>
-          Toilet name
-          <input
-            name="name"
-            type="text"
-            className={controls.text}
-            value={loo.name === null ? '' : loo.name}
-            onChange={handleChange}
-            data-testid="toilet-name"
-          />
-        </label>
-
-        <label>
-          Who can access?
-          <select
-            name="access"
-            className={controls.dropdown}
-            value={loo.access === null ? '' : loo.access}
-            onChange={handleChange}
-            data-testid="who-can-access"
-          >
-            <option value="">Unknown</option>
-            {optionsMap.access.map((option, index) => (
-              <option key={index} value={option.value}>
-                {option.name}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label>
-          Facilities
-          <select
-            name="type"
-            className={controls.dropdown}
-            value={loo.type === null ? '' : loo.type}
-            onChange={handleChange}
-            data-testid="facilities"
-          >
-            <option value="">Unknown</option>
-            {optionsMap.type.map((option, index) => (
-              <option key={index} value={option.value}>
-                {option.name}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label>
-          Accessible facilities
-          <select
-            name="accessibleType"
-            className={controls.dropdown}
-            value={loo.accessibleType === null ? '' : loo.accessibleType}
-            onChange={handleChange}
-            data-testid="accessible-facilities"
-          >
-            <option value="">Unknown</option>
-            {optionsMap.type.map((option, index) => (
-              <option key={index} value={option.value}>
-                {option.name}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label>
-          Opening hours
-          <select
-            name="opening"
-            className={controls.dropdown}
-            value={loo.opening === null ? '' : loo.opening}
-            onChange={handleChange}
-            data-testid="opening-hours"
-          >
-            <option value="">Unknown</option>
-            {optionsMap.opening.map((option, index) => (
-              <option key={index} value={option.value}>
-                {option.name}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <div className={styles.questionnaire}>
-          <div>
-            <span className={styles.questionnaireCol} />
-            <span className={styles.questionnaireCol} id="yes">
-              Yes
-            </span>
-            <span className={styles.questionnaireCol} id="no">
-              No
-            </span>
-            <span className={styles.questionnaireCol} id="unknown">
-              Don't know
-            </span>
-          </div>
-
-          {questionnaireMap.map((q, index) => (
-            <fieldset key={index} className={styles.questionnaireGroup}>
-              <legend className={helpers.visuallyHidden}>{q.question}</legend>
-              <span className={styles.questionnaireCol}>{q.question}</span>
-              <input
-                name={q.property}
-                className={styles.questionnaireCol}
-                type="radio"
-                value={true}
-                aria-labelledby="yes"
-                checked={loo[q.property] === true}
-                onChange={handleTriStateChange}
-                data-testid={`${q.property}:yes`}
-              />
-              <input
-                name={q.property}
-                className={styles.questionnaireCol}
-                type="radio"
-                value={false}
-                aria-labelledby="no"
-                checked={loo[q.property] === false}
-                onChange={handleTriStateChange}
-                data-testid={`${q.property}:no`}
-              />
-              <input
-                name={q.property}
-                className={styles.questionnaireCol}
-                type="radio"
-                value=""
-                aria-labelledby="unknown"
-                checked={loo[q.property] === ''}
-                onChange={handleTriStateChange}
-                data-testid={`${q.property}:unknown`}
-              />
-            </fieldset>
-          ))}
-        </div>
-
-        <label>
-          Fee?
-          <input
-            name="fee"
-            type="text"
-            className={controls.text}
-            value={loo.fee === null ? '' : loo.fee}
-            placeholder="The amount e.g. £0.10"
-            onChange={handleChange}
-            data-testid="fee"
-          />
-        </label>
-
-        <label>
-          Any notes?
-          <textarea
-            name="notes"
-            className={controls.text}
-            value={loo.notes === null ? '' : loo.notes}
-            onChange={handleChange}
-            data-testid="notes"
-          />
-        </label>
-
-        <h3 className={headings.regular}>Data for this toilet</h3>
-
-        <div className={styles.data}>
-          <label>
-            Latitude
-            <input
-              type="text"
-              name="geometry.coordinates.0"
-              className={controls.text}
-              value={center.lat}
-              readOnly={true}
-            />
-          </label>
-
-          <label>
-            Longitude
-            <input
-              type="text"
-              name="geometry.coordinates.1"
-              className={controls.text}
-              data-testid="loo-name"
-              value={center.lng}
-              readOnly={true}
-            />
-          </label>
-        </div>
-
-        {saveLoading && <Loading message={'Saving your changes...'} />}
-
-        {
-          // This message probably won't be seen, but just in case the redirect fails...
-          saveResponse && saveResponse.submitReport.code === '200' && (
-            <Notification>
-              Successfully saved changes! Redirecting&hellip;
-            </Notification>
-          )
-        }
-
-        {
-          // TODO better error message?
-          (saveError ||
-            (saveResponse && saveResponse.submitReport.code !== '200')) && (
-            <Notification>
-              Oops, there was an error saving your changes.
-              {console.log(saveError, saveResponse)}
-            </Notification>
-          )
-        }
-
-        <div className={controls.btnStack}>
-          <input
-            type="submit"
-            className={controls.btn}
-            onClick={save}
-            value="Add the toilet"
-            data-testid="add-the-toilet"
-          />
-        </div>
-      </div>
-    );
-  };
-
-  const renderMap = () => {
-    return (
-      <LooMap
-        loos={data}
-        center={mapPosition.center}
-        minZoom={config.editMinZoom}
-        onMoveEnd={setMapPosition}
-        showCenter
-        showSearchControl
-      />
-    );
-  };
-
-  return <PageLayout main={renderMain()} map={renderMap()} />;
+  return <PageLayout main={<MainFragment />} map={<MapFragment />} />;
 };
 
 AddPage.propTypes = {

--- a/src/pages/EditPage.js
+++ b/src/pages/EditPage.js
@@ -2,57 +2,32 @@ import React, { useState, useEffect } from 'react';
 import { PropTypes } from 'prop-types';
 import { Link } from 'react-router-dom';
 import uniqBy from 'lodash/uniqBy';
-import isEmpty from 'lodash/isEmpty';
 import cloneDeep from 'lodash/cloneDeep';
 import merge from 'lodash/merge';
-import set from 'lodash/set';
-import transform from 'lodash/transform';
-import isObject from 'lodash/isObject';
+import { loader } from 'graphql.macro';
+import { useQuery, useMutation } from '@apollo/client';
 
 import PageLayout from '../components/PageLayout';
 import Loading from '../components/Loading';
 import LooMap from '../components/LooMap';
-import useNearbyLoos from '../components/useNearbyLoos';
 import EntryForm from '../components/EntryForm';
+import useNearbyLoos from '../components/useNearbyLoos';
+import useMapPosition from '../components/useMapPosition';
 
 import config from '../config';
 import graphqlMappings from '../graphqlMappings';
+import history from '../history';
+import questionnaireMap from '../questionnaireMap';
 
 import controls from '../css/controls.module.css';
-
-import { useQuery, useMutation } from '@apollo/client';
-import { loader } from 'graphql.macro';
-import history from '../history';
-import useMapPosition from '../components/useMapPosition';
 
 const FIND_BY_ID = loader('./findLooById.graphql');
 const UPDATE_LOO = loader('./updateLoo.graphql');
 
-const getLooCachedId = (looId) => `Loo: ${looId}`;
-
-const questionnaireMap = [
-  {
-    question: 'Attended?',
-    property: 'attended',
-  },
-  {
-    question: 'Baby changing?',
-    property: 'babyChange',
-  },
-  {
-    question: 'Automatic?',
-    property: 'automatic',
-  },
-  {
-    question: 'Radar key?',
-    property: 'radar',
-  },
-];
-
 const EditPage = (props) => {
   const optionsMap = graphqlMappings.looProps.definitions;
 
-  // Find the raw loo data for the given loo
+  // find the raw loo data for the given loo
   const { loading: loadingLooData, data: looData, error: looError } = useQuery(
     FIND_BY_ID,
     {
@@ -70,21 +45,15 @@ const EditPage = (props) => {
     radius: mapPosition.radius,
   });
 
-  // Local state mapCenter to get fix issues with react-leaflet not being stateless and lat lng rounding issues
+  // local state mapCenter to get fix issues with react-leaflet not being stateless and lat lng rounding issues
   const [mapCenter, setMapCenter] = useState();
 
-  // LooState is the temporary loo object that hold's the user's representation of the loo
-  const [looState, setLooState] = useState();
-
-  // Original is compared against LooState when saving changes
-  const [original, setOriginal] = useState();
+  const [initialData, setInitialData] = useState();
 
   useEffect(() => {
     if (!looData) {
       return;
     }
-
-    let looDataToUse = looData.loo;
 
     let tempLoo = {
       active: null,
@@ -97,79 +66,25 @@ const EditPage = (props) => {
       fee: '',
     };
 
-    // Set questionnaire loo property defaults
+    // set questionnaire loo property defaults
     questionnaireMap.forEach((q) => {
       tempLoo[q.property] = '';
     });
 
-    // Deep extend loo state to ensure we get all properties (since we can't guarantee
+    // deep extend loo state to ensure we get all properties (since we can't guarantee
     // that `looData` will include them all)
-    let newLoo = merge({}, tempLoo, looDataToUse);
-    setLooState(newLoo);
+    const newLoo = cloneDeep(merge({}, tempLoo, looData.loo));
     setMapCenter(newLoo.location);
 
-    // Keep track of defaults so we only submit new information
-    setOriginal({
-      loo: cloneDeep(newLoo),
-      center: newLoo.location,
+    // keep track of defaults so we only submit new information
+    setInitialData({
+      loo: newLoo,
+      center: {
+        lat: newLoo.location.lat,
+        lng: newLoo.location.lng,
+      },
     });
   }, [looData]);
-
-  const handleChange = (event) => {
-    // Avoid state mutation
-    let loo = cloneDeep(looState);
-
-    // Sets nested loo property value
-    set(loo, event.target.name, event.target.value);
-
-    setLooState(loo);
-  };
-
-  const handleTriStateChange = (event) => {
-    let val;
-    switch (event.target.value) {
-      case 'true':
-        val = true;
-        break;
-      case 'false':
-        val = false;
-        break;
-      default:
-        val = event.target.value;
-    }
-
-    // Avoid state mutation
-    var loo = cloneDeep(looState);
-
-    set(loo, event.target.name, val);
-
-    setLooState(loo);
-  };
-
-  const getNovelInput = () => {
-    const before = cloneDeep(original.loo);
-    const now = cloneDeep(looState);
-
-    // Add the active state for which there's no user-facing form control as yet.
-    now.active = true;
-
-    // Add location
-    before.location = {
-      lng: original.center.lng,
-      lat: original.center.lat,
-    };
-
-    let center = mapCenter;
-    now.location = {
-      lng: center.lng,
-      lat: center.lat,
-    };
-
-    // Keep only new or changed data, by comparing to the form's initial state
-    const changes = onlyChanges(now, before);
-
-    return changes;
-  };
 
   const [
     updateLoo,
@@ -180,35 +95,33 @@ const EditPage = (props) => {
     console.error('error saving:', saveError);
   }
 
-  // Redirect to thanks page if successfully made changes
+  // redirect to thanks page if successfully made changes
   if (saveResponse && saveResponse.submitReport.code === '200') {
     history.push(`/loos/${saveResponse.submitReport.loo.id}/thanks`);
   }
 
-  const save = () => {
-    const changes = getNovelInput();
+  const save = (data, dirtyFields) => {
+    const id = looData.loo.id;
 
-    // Always associate geometry with a report, even if unchanged
-    let center = mapCenter;
-    changes.location = {
-      lng: center.lng,
-      lat: center.lat,
-    };
-
-    // Set questionnaire options to null before transport.
-    questionnaireMap.forEach((q) => {
-      if (changes[q.property] === '') changes[q.property] = null;
+    let changes = {};
+    dirtyFields.forEach((field) => {
+      changes[field] = data[field];
     });
 
-    let id = looData.loo.id;
+    // always associate geometry with a report, even if unchanged
+    // omits __typename
+    changes.location = {
+      lat: mapCenter.lat,
+      lng: mapCenter.lng,
+    };
+
     changes.id = id;
 
     // Evict the loo from the cache before updating - Apollo
     // is normally smart and can work out when something's changed, but
     // in this case it doesn't and stale data can persist without
     // a cache eviction
-    let cache = props.cache;
-    cache.evict(getLooCachedId(id));
+    props.cache.evict(`Loo: ${id}`);
 
     updateLoo({
       variables: changes,
@@ -225,30 +138,31 @@ const EditPage = (props) => {
       };
     }
 
-    // Only return the active loos once (activeLoo must be first in array)
+    // only return the active loos once (activeLoo must be first in array)
     return uniqBy([activeLoo, ...data], 'id').filter(Boolean);
   };
 
-  if (loadingLooData || !looData || !looState) {
+  if (loadingLooData || !looData || !initialData) {
     return (
       <PageLayout
-        main={<Loading message={'Fetching Toilet Data'} />}
-        map={<Loading message={'Fetching Toilet Data'} />}
+        main={<Loading message="Fetching Toilet Data" />}
+        map={<Loading message="Fetching Toilet Data" />}
       />
     );
   }
 
   if (looError) {
     console.error(looError);
+
     return (
       <PageLayout
-        main={<Loading message={'Error fetching toilet data'} />}
-        map={<Loading message={'Error fetching toilet data'} />}
+        main={<Loading message="Error fetching toilet data" />}
+        map={<Loading message="Error fetching toilet data" />}
       />
     );
   }
 
-  // Redirect to index if loo is not active (i.e. removed)
+  // redirect to index if loo is not active (i.e. removed)
   if (looData && !looData.loo.active) {
     history.push(`/`);
   }
@@ -270,59 +184,42 @@ const EditPage = (props) => {
   const MainFragment = () => (
     <EntryForm
       map={<MapFragment />}
-      loo={looState}
+      loo={initialData.loo}
       center={mapCenter}
-      handleChange={handleChange}
-      handleTriStateChange={handleTriStateChange}
       questionnaireMap={questionnaireMap}
       saveLoading={saveLoading}
       saveResponse={saveResponse}
       saveError={saveError}
       optionsMap={optionsMap}
-      actions={[
-        <input
-          type="submit"
-          className={controls.btn}
-          onClick={save}
-          value="Update the toilet"
-          disabled={isEmpty(getNovelInput())}
-        />,
-        <Link
-          to={`/loos/${props.match.params.id}/remove`}
-          className={controls.btnCaution}
-        >
-          Remove the toilet
-        </Link>,
-      ]}
-    />
+      onSubmit={save}
+    >
+      {({ dirtyFields }) => (
+        <>
+          <input
+            type="submit"
+            className={controls.btn}
+            value="Update the toilet"
+            disabled={!dirtyFields.size}
+          />
+
+          <Link
+            to={`/loos/${props.match.params.id}/remove`}
+            className={controls.btnCaution}
+          >
+            Remove the toilet
+          </Link>
+        </>
+      )}
+    </EntryForm>
   );
 
   return <PageLayout main={<MainFragment />} map={<MapFragment />} />;
 };
 
 EditPage.propTypes = {
-  cache: PropTypes.object,
+  cache: PropTypes.shape({
+    evict: PropTypes.func.isRequired,
+  }).isRequired,
 };
-
-/**
- * Only keep fields in loo that are different to their corresponding field in
- * from.
- *
- * This is used to only submit novel or differing information in reports.
- */
-function onlyChanges(loo, from) {
-  return transform(loo, (acc, value, key) => {
-    if (isObject(value)) {
-      // Deeply compare
-      const nestedChanges = onlyChanges(value, from[key]);
-      if (!isEmpty(nestedChanges)) {
-        acc[key] = nestedChanges;
-      }
-    } else if (value !== from[key]) {
-      // Only keep a value in loo if it is changed
-      acc[key] = value;
-    }
-  });
-}
 
 export default EditPage;

--- a/src/pages/EditPage.js
+++ b/src/pages/EditPage.js
@@ -100,20 +100,8 @@ const EditPage = (props) => {
     history.push(`/loos/${saveResponse.submitReport.loo.id}/thanks`);
   }
 
-  const save = (data, dirtyFields) => {
+  const save = (data) => {
     const id = looData.loo.id;
-
-    let changes = {
-      // always associate geometry with a report, even if unchanged
-      location: data.location,
-    };
-
-    // only include fields which have been modified
-    dirtyFields.forEach((field) => {
-      changes[field] = data[field];
-    });
-
-    changes.id = id;
 
     // Evict the loo from the cache before updating - Apollo
     // is normally smart and can work out when something's changed, but
@@ -122,7 +110,10 @@ const EditPage = (props) => {
     props.cache.evict(`Loo: ${id}`);
 
     updateLoo({
-      variables: changes,
+      variables: {
+        ...data,
+        id,
+      },
     });
   };
 
@@ -191,13 +182,13 @@ const EditPage = (props) => {
       optionsMap={optionsMap}
       onSubmit={save}
     >
-      {({ dirtyFields }) => (
+      {({ hasDirtyFields }) => (
         <>
           <input
             type="submit"
             className={controls.btn}
             value="Update the toilet"
-            disabled={!dirtyFields.size}
+            disabled={!hasDirtyFields}
           />
 
           <Link

--- a/src/pages/EditPage.js
+++ b/src/pages/EditPage.js
@@ -103,17 +103,15 @@ const EditPage = (props) => {
   const save = (data, dirtyFields) => {
     const id = looData.loo.id;
 
-    let changes = {};
+    let changes = {
+      // always associate geometry with a report, even if unchanged
+      location: data.location,
+    };
+
+    // only include fields which have been modified
     dirtyFields.forEach((field) => {
       changes[field] = data[field];
     });
-
-    // always associate geometry with a report, even if unchanged
-    // omits __typename
-    changes.location = {
-      lat: mapCenter.lat,
-      lng: mapCenter.lng,
-    };
 
     changes.id = id;
 
@@ -167,7 +165,7 @@ const EditPage = (props) => {
     history.push(`/`);
   }
 
-  const MapFragment = () => (
+  const mapFragment = (
     <LooMap
       loos={getLoosToDisplay()}
       center={mapCenter}
@@ -181,9 +179,9 @@ const EditPage = (props) => {
     />
   );
 
-  const MainFragment = () => (
+  const mainFragment = (
     <EntryForm
-      map={<MapFragment />}
+      map={mapFragment}
       loo={initialData.loo}
       center={mapCenter}
       questionnaireMap={questionnaireMap}
@@ -213,7 +211,7 @@ const EditPage = (props) => {
     </EntryForm>
   );
 
-  return <PageLayout main={<MainFragment />} map={<MapFragment />} />;
+  return <PageLayout main={mainFragment} map={mapFragment} />;
 };
 
 EditPage.propTypes = {

--- a/src/pages/EditPage.js
+++ b/src/pages/EditPage.js
@@ -1,24 +1,23 @@
 import React, { useState, useEffect } from 'react';
 import { PropTypes } from 'prop-types';
-
 import { Link } from 'react-router-dom';
-import MediaQuery from 'react-responsive';
-import _ from 'lodash';
+import uniqBy from 'lodash/uniqBy';
+import isEmpty from 'lodash/isEmpty';
+import cloneDeep from 'lodash/cloneDeep';
+import merge from 'lodash/merge';
+import set from 'lodash/set';
+import transform from 'lodash/transform';
+import isObject from 'lodash/isObject';
 
 import PageLayout from '../components/PageLayout';
 import Loading from '../components/Loading';
 import LooMap from '../components/LooMap';
-import DismissableBox from '../components/DismissableBox';
-import Notification from '../components/Notification';
 import useNearbyLoos from '../components/useNearbyLoos';
+import EntryForm from '../components/EntryForm';
 
 import config from '../config';
 import graphqlMappings from '../graphqlMappings';
 
-import styles from './css/edit-loo-page.module.css';
-import layout from '../components/css/layout.module.css';
-import helpers from '../css/helpers.module.css';
-import headings from '../css/headings.module.css';
 import controls from '../css/controls.module.css';
 
 import { useQuery, useMutation } from '@apollo/client';
@@ -29,7 +28,7 @@ import useMapPosition from '../components/useMapPosition';
 const FIND_BY_ID = loader('./findLooById.graphql');
 const UPDATE_LOO = loader('./updateLoo.graphql');
 
-const getLooCachedId = (looId) => 'Loo:' + looId;
+const getLooCachedId = (looId) => `Loo: ${looId}`;
 
 const questionnaireMap = [
   {
@@ -105,23 +104,23 @@ const EditPage = (props) => {
 
     // Deep extend loo state to ensure we get all properties (since we can't guarantee
     // that `looData` will include them all)
-    let newLoo = _.merge({}, tempLoo, looDataToUse);
+    let newLoo = merge({}, tempLoo, looDataToUse);
     setLooState(newLoo);
     setMapCenter(newLoo.location);
 
     // Keep track of defaults so we only submit new information
     setOriginal({
-      loo: _.cloneDeep(newLoo),
+      loo: cloneDeep(newLoo),
       center: newLoo.location,
     });
   }, [looData]);
 
   const handleChange = (event) => {
     // Avoid state mutation
-    let loo = _.cloneDeep(looState);
+    let loo = cloneDeep(looState);
 
     // Sets nested loo property value
-    _.set(loo, event.target.name, event.target.value);
+    set(loo, event.target.name, event.target.value);
 
     setLooState(loo);
   };
@@ -140,16 +139,16 @@ const EditPage = (props) => {
     }
 
     // Avoid state mutation
-    var loo = _.cloneDeep(looState);
+    var loo = cloneDeep(looState);
 
-    _.set(loo, event.target.name, val);
+    set(loo, event.target.name, val);
 
     setLooState(loo);
   };
 
   const getNovelInput = () => {
-    const before = _.cloneDeep(original.loo);
-    const now = _.cloneDeep(looState);
+    const before = cloneDeep(original.loo);
+    const now = cloneDeep(looState);
 
     // Add the active state for which there's no user-facing form control as yet.
     now.active = true;
@@ -216,267 +215,6 @@ const EditPage = (props) => {
     });
   };
 
-  const renderMain = () => {
-    const loo = looState;
-    const center = mapCenter;
-
-    return (
-      <div>
-        <div>
-          <div className={layout.controls}>
-            {config.showBackButtons && (
-              <button onClick={props.history.goBack} className={controls.btn}>
-                Back
-              </button>
-            )}
-          </div>
-        </div>
-
-        <h2 className={headings.large}>Update This Toilet</h2>
-
-        <MediaQuery maxWidth={config.viewport.mobile}>
-          <div className={styles.mobileMap}>{renderMap()}</div>
-        </MediaQuery>
-
-        <Notification>
-          <p>Align the crosshair with where you believe the toilet to be.</p>
-        </Notification>
-
-        <DismissableBox
-          persistKey="edit-welcome"
-          title="Welcome Contributor!"
-          content="Please fill in everything you can about the toilet below."
-        />
-
-        <label>
-          Toilet name
-          <input
-            name="name"
-            type="text"
-            className={controls.text}
-            value={loo.name === null ? '' : loo.name}
-            onChange={handleChange}
-            data-testid="toilet-name"
-          />
-        </label>
-
-        <label>
-          Who can access?
-          <select
-            name="access"
-            className={controls.dropdown}
-            value={loo.access === null ? '' : loo.access}
-            onChange={handleChange}
-            data-testid="who-can-access"
-          >
-            <option value="">Unknown</option>
-            {optionsMap.access.map((option, index) => (
-              <option key={index} value={option.value}>
-                {option.name}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label>
-          Facilities
-          <select
-            name="type"
-            className={controls.dropdown}
-            value={loo.type === null ? '' : loo.type}
-            onChange={handleChange}
-            data-testid="facilities"
-          >
-            <option value="">Unknown</option>
-            {optionsMap.type.map((option, index) => (
-              <option key={index} value={option.value}>
-                {option.name}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label>
-          Accessible facilities
-          <select
-            name="accessibleType"
-            className={controls.dropdown}
-            value={loo.accessibleType === null ? '' : loo.accessibleType}
-            onChange={handleChange}
-            data-testid="accessible-facilities"
-          >
-            <option value="">Unknown</option>
-            {optionsMap.type.map((option, index) => (
-              <option key={index} value={option.value}>
-                {option.name}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label>
-          Opening hours
-          <select
-            name="opening"
-            className={controls.dropdown}
-            value={loo.opening === null ? '' : loo.opening}
-            onChange={handleChange}
-            data-testid="opening-hours"
-          >
-            <option value="">Unknown</option>
-            {optionsMap.opening.map((option, index) => (
-              <option key={index} value={option.value}>
-                {option.name}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <div className={styles.questionnaire}>
-          <div>
-            <span className={styles.questionnaireCol} />
-            <span className={styles.questionnaireCol} id="yes">
-              Yes
-            </span>
-            <span className={styles.questionnaireCol} id="no">
-              No
-            </span>
-            <span className={styles.questionnaireCol} id="unknown">
-              Don't know
-            </span>
-          </div>
-
-          {questionnaireMap.map((q, index) => (
-            <fieldset key={index} className={styles.questionnaireGroup}>
-              <legend className={helpers.visuallyHidden}>{q.question}</legend>
-              <span className={styles.questionnaireCol}>{q.question}</span>
-              <input
-                name={q.property}
-                className={styles.questionnaireCol}
-                type="radio"
-                value={true}
-                aria-labelledby="yes"
-                checked={loo[q.property] === true}
-                onChange={handleTriStateChange}
-                data-testid={`${q.property}:yes`}
-              />
-              <input
-                name={q.property}
-                className={styles.questionnaireCol}
-                type="radio"
-                value={false}
-                aria-labelledby="no"
-                checked={loo[q.property] === false}
-                onChange={handleTriStateChange}
-                data-testid={`${q.property}:no`}
-              />
-              <input
-                name={q.property}
-                className={styles.questionnaireCol}
-                type="radio"
-                value=""
-                aria-labelledby="unknown"
-                checked={loo[q.property] === ''}
-                onChange={handleTriStateChange}
-                data-testid={`${q.property}:unknown`}
-              />
-            </fieldset>
-          ))}
-        </div>
-
-        <label>
-          Fee?
-          <input
-            name="fee"
-            type="text"
-            className={controls.text}
-            value={loo.fee === null ? '' : loo.fee}
-            placeholder="The amount e.g. £0.10"
-            onChange={handleChange}
-            data-testid="fee"
-          />
-        </label>
-
-        <label>
-          Any notes?
-          <textarea
-            name="notes"
-            className={controls.text}
-            value={loo.notes === null ? '' : loo.notes}
-            onChange={handleChange}
-            data-testid="notes"
-          />
-        </label>
-
-        <h3 className={headings.regular}>Data for this toilet</h3>
-
-        <div className={styles.data}>
-          <label>
-            Latitude
-            <input
-              type="text"
-              name="geometry.coordinates.0"
-              className={controls.text}
-              value={center.lat}
-              readOnly={true}
-            />
-          </label>
-
-          <label>
-            Longitude
-            <input
-              type="text"
-              name="geometry.coordinates.1"
-              className={controls.text}
-              data-testid="loo-name"
-              value={center.lng}
-              readOnly={true}
-            />
-          </label>
-        </div>
-
-        {saveLoading && <Loading message={'Saving your changes...'} />}
-
-        {
-          // This message probably won't be seen, but just in case the redirect fails...
-          saveResponse && saveResponse.submitReport.code === '200' && (
-            <Notification>
-              Successfully saved changes! Redirecting&hellip;
-            </Notification>
-          )
-        }
-
-        {
-          // TODO better error message?
-          (saveError ||
-            (saveResponse && saveResponse.submitReport.code !== '200')) && (
-            <Notification>
-              Oops, there was an error saving your changes.
-              {console.log(saveError, saveResponse)}
-            </Notification>
-          )
-        }
-
-        <div className={controls.btnStack}>
-          <input
-            type="submit"
-            className={controls.btn}
-            onClick={save}
-            value="Update the toilet"
-            disabled={_.isEmpty(getNovelInput())}
-          />
-
-          <Link
-            to={`/loos/${props.match.params.id}/remove`}
-            className={controls.btnCaution}
-          >
-            Remove the toilet
-          </Link>
-        </div>
-      </div>
-    );
-  };
-
   const getLoosToDisplay = () => {
     let activeLoo;
 
@@ -488,23 +226,7 @@ const EditPage = (props) => {
     }
 
     // Only return the active loos once (activeLoo must be first in array)
-    return _.uniqBy([activeLoo, ...data], 'id').filter(Boolean);
-  };
-
-  const renderMap = () => {
-    return (
-      <LooMap
-        loos={getLoosToDisplay()}
-        center={mapCenter}
-        minZoom={config.editMinZoom}
-        onMoveEnd={(mapPosition) => {
-          setMapCenter(mapPosition.center);
-          setMapPosition(mapPosition);
-        }}
-        showCenter
-        showSearchControl
-      />
-    );
+    return uniqBy([activeLoo, ...data], 'id').filter(Boolean);
   };
 
   if (loadingLooData || !looData || !looState) {
@@ -531,7 +253,51 @@ const EditPage = (props) => {
     history.push(`/`);
   }
 
-  return <PageLayout main={renderMain()} map={renderMap()} />;
+  const MapFragment = () => (
+    <LooMap
+      loos={getLoosToDisplay()}
+      center={mapCenter}
+      minZoom={config.editMinZoom}
+      onMoveEnd={(mapPosition) => {
+        setMapCenter(mapPosition.center);
+        setMapPosition(mapPosition);
+      }}
+      showCenter
+      showSearchControl
+    />
+  );
+
+  const MainFragment = () => (
+    <EntryForm
+      map={<MapFragment />}
+      loo={looState}
+      center={mapCenter}
+      handleChange={handleChange}
+      handleTriStateChange={handleTriStateChange}
+      questionnaireMap={questionnaireMap}
+      saveLoading={saveLoading}
+      saveResponse={saveResponse}
+      saveError={saveError}
+      optionsMap={optionsMap}
+      actions={[
+        <input
+          type="submit"
+          className={controls.btn}
+          onClick={save}
+          value="Update the toilet"
+          disabled={isEmpty(getNovelInput())}
+        />,
+        <Link
+          to={`/loos/${props.match.params.id}/remove`}
+          className={controls.btnCaution}
+        >
+          Remove the toilet
+        </Link>,
+      ]}
+    />
+  );
+
+  return <PageLayout main={<MainFragment />} map={<MapFragment />} />;
 };
 
 EditPage.propTypes = {
@@ -545,11 +311,11 @@ EditPage.propTypes = {
  * This is used to only submit novel or differing information in reports.
  */
 function onlyChanges(loo, from) {
-  return _.transform(loo, (acc, value, key) => {
-    if (_.isObject(value)) {
+  return transform(loo, (acc, value, key) => {
+    if (isObject(value)) {
       // Deeply compare
       const nestedChanges = onlyChanges(value, from[key]);
-      if (!_.isEmpty(nestedChanges)) {
+      if (!isEmpty(nestedChanges)) {
         acc[key] = nestedChanges;
       }
     } else if (value !== from[key]) {

--- a/src/pages/LooPage.js
+++ b/src/pages/LooPage.js
@@ -156,14 +156,18 @@ const LooPage = (props) => {
     return loo;
   });
 
-  const mapFragment = !looLocation ? null : (
-    <LooMap
-      loos={loosToDisplay}
-      center={mapPosition.center}
-      zoom={mapPosition.zoom}
-      onMoveEnd={setMapPosition}
-    />
-  );
+  let mapFragment = null;
+
+  if (looLocation) {
+    mapFragment = (
+      <LooMap
+        loos={loosToDisplay}
+        center={mapPosition.center}
+        zoom={mapPosition.zoom}
+        onMoveEnd={setMapPosition}
+      />
+    );
+  }
 
   if (loading || error || userLoading || userError || !data.loo) {
     let msg;

--- a/src/questionnaireMap.js
+++ b/src/questionnaireMap.js
@@ -1,0 +1,18 @@
+export default [
+  {
+    question: 'Attended?',
+    property: 'attended',
+  },
+  {
+    question: 'Baby changing?',
+    property: 'babyChange',
+  },
+  {
+    question: 'Automatic?',
+    property: 'automatic',
+  },
+  {
+    question: 'Radar key?',
+    property: 'radar',
+  },
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -11119,6 +11119,11 @@ react-helmet@6.0.0:
     react-fast-compare "^2.0.4"
     react-side-effect "^2.1.0"
 
+react-hook-form@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-5.6.0.tgz#309fbd9780d5d091c6e96796d82d16e0cc5849eb"
+  integrity sha512-/WGDFdrkooe71SKV1IB5bRRWmPHohQW2GfEYivc1mRGEuTIKIzNeAeSLZzTUzAXMVXcoCk2147mb15QwkoyIng==
+
 react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
Difficult to know, without tests if, whether this actually breaks everything.

* Added `<form>` element
* Abstracted `EntryForm` into shared component for `AddPage` and `EditPage`
* Added `react-hook-form` dependency