### PR TITLE
fix: remove direct cache manipulation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -111,5 +111,4 @@ const App = (props) => {
   return <ApolloProvider client={client} children={props.children} />;
 };
 
-export { cache };
 export default App;

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ import PageLoading from './components/PageLoading';
 import history from './history';
 import Router from './Router';
 import AuthProvider from './Auth';
-import App, { cache } from './App';
+import App from './App';
 
 const Explorer = lazy(() => import('./explorer'));
 
@@ -61,17 +61,8 @@ ReactDOM.render(
               path="/explorer"
               render={(props) => <Explorer {...props} />}
             />
-            <ProtectedRoute
-              exact
-              path="/report"
-              injectProps={{ cache }}
-              component={AddPage}
-            />
-            <ProtectedRoute
-              path="/loos/:id/edit"
-              injectProps={{ cache }}
-              component={EditPage}
-            />
+            <ProtectedRoute exact path="/report" component={AddPage} />
+            <ProtectedRoute path="/loos/:id/edit" component={EditPage} />
             <ProtectedRoute path="/loos/:id/remove" component={RemovePage} />
             <ProtectedRoute path="/loos/:id/thanks" component={LooPage} />
             <Route component={NotFound} />

--- a/src/pages/EditPage.js
+++ b/src/pages/EditPage.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { PropTypes } from 'prop-types';
 import { Link } from 'react-router-dom';
 import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
@@ -115,12 +114,6 @@ const EditPage = (props) => {
   const save = (data) => {
     const id = looData.loo.id;
 
-    // Evict the loo from the cache before updating - Apollo
-    // is normally smart and can work out when something's changed, but
-    // in this case it doesn't and stale data can persist without
-    // a cache eviction
-    props.cache.evict(`Loo: ${id}`);
-
     updateLoo({
       variables: {
         ...data,
@@ -216,12 +209,6 @@ const EditPage = (props) => {
   );
 
   return <PageLayout main={mainFragment} map={mapFragment} />;
-};
-
-EditPage.propTypes = {
-  cache: PropTypes.shape({
-    evict: PropTypes.func.isRequired,
-  }).isRequired,
 };
 
 export default EditPage;


### PR DESCRIPTION
This direct cache manipulation could cause some problems where if the mutation fails, we'll be left with no cached toilet data as it's been evicted before the mutation is called.

#602 implements [this approach](https://www.apollographql.com/docs/react/v3.0-beta/data/mutations/#updating-a-single-existing-entity) to ensuring the cache gets updated with new data after the update loo mutation so the cache manipluation is no longer required 