### PR TITLE
fix: ie11 missing fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "query-string": "6.12.1",
     "react": "16.13.1",
     "react-animated-number": "0.4.4",
+    "react-app-polyfill": "1.0.6",
     "react-chartjs-2": "2.9.0",
     "react-dom": "16.13.1",
     "react-ga": "2.7.0",
@@ -97,7 +98,8 @@
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",
-      "last 1 safari version"
+      "last 1 safari version",
+      "ie 11"
     ]
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 // Polyfills
+import 'react-app-polyfill/ie11';
+
 import 'core-js/features/array/find';
 import 'core-js/features/array/includes';
 import 'core-js/features/string/repeat';
 import 'core-js/features/object/entries';
-import 'core-js/features/object/assign';
 
 import React, { Suspense, lazy } from 'react';
 import ReactDOM from 'react-dom';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10968,7 +10968,7 @@ react-animated-number@0.4.4:
     prop-types "^15.5.8"
     raf "^3.2.0"
 
-react-app-polyfill@^1.0.6:
+react-app-polyfill@1.0.6, react-app-polyfill@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-1.0.6.tgz#890f8d7f2842ce6073f030b117de9130a5f385f0"
   integrity sha512-OfBnObtnGgLGfweORmdZbyEz+3dgVePQBb3zipiaDsMHV1NpWm0rDFYIVXFV/AK+x4VIIfWHhrdMIeoTLyRr2g==


### PR DESCRIPTION
- Adds ie11 to development browserlist to allow dev server to work with ie11 (https://medium.com/@matwankarmalay/create-react-app-ie11-script1002-syntax-error-how-to-get-rid-of-it-d70000c53ddf)
- Adds `react-app-polyfill` which includes fetch (https://github.com/facebook/create-react-app/blob/master/packages/react-app-polyfill/README.md)

we could also use `react-app-polyfill/stable` to replace our individual polyfills but I think it includes more than we need and adds 20Kb + bundle size

Fixes #410 

