### PR TITLE
fix: turn off safari autocorrect for location search

### DIFF
--- a/src/components/LocationSearch/LocationSearch.js
+++ b/src/components/LocationSearch/LocationSearch.js
@@ -75,6 +75,7 @@ const LocationSearch = ({ onSelectedItemChange }) => {
           <input
             onFocus={() => setInputValue('')}
             placeholder="Search for a location"
+            autoComplete="off"
             className={styles.input}
             style={{
               borderRadius: isOpen ? '5px 5px 0 0' : 5,


### PR DESCRIPTION
This was causing some focus problems on macOS Safari, probably best to remove it anyway for those peculiar place names