### PR TITLE
fix: avoid :first-child error

### DIFF
--- a/src/components/LooMap/LooMap.js
+++ b/src/components/LooMap/LooMap.js
@@ -148,7 +148,7 @@ const LooMap = ({
             border: 1px solid ${theme.colors.primary};
             border-radius: 20px;
 
-            &:not(:first-child) {
+            &:not(:first-of-type) {
               margin-top: 10px;
             }
           }


### PR DESCRIPTION
Should have the same effect and avoids the console error:

> index.js:1 The pseudo class ":first-child" is potentially unsafe when doing server-side rendering. Try changing it to ":first-of-type". 