### PR TITLE
fix: reorder DOM so sidebar is before map

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { useTheme } from 'emotion-theming';
 import isPropValid from '@emotion/is-prop-valid';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faFilter,
   faAngleRight,
@@ -10,12 +11,15 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { NavLink } from 'react-router-dom';
 
+import { Media } from '../components/Media';
 import VisuallyHidden from './VisuallyHidden';
 import Box from './Box';
 import Text from './Text';
 import Icon from './Icon';
 import LocationSearch from './LocationSearch';
 import Filters from './Filters';
+import Button from '../components/Button';
+import Drawer from '../components/Drawer';
 
 const Arrow = styled((props) => <Icon icon={faAngleRight} {...props} />, {
   shouldForwardProp: (prop) => {
@@ -44,100 +48,174 @@ const Sidebar = ({
   filters,
   onFilterChange,
   onSelectedItemChange,
+  onUpdateMapPosition,
   mapCenter,
 }) => {
   const theme = useTheme();
   const [isFilterExpanded, setIsFilterExpanded] = useState(false);
+  const [isFiltersExpanded, setIsFiltersExpanded] = useState(false);
+  const filterToggleRef = useRef(null);
 
   return (
-    <Box
-      position="absolute"
-      top={3}
-      left={3}
-      p={4}
-      borderRadius={35}
-      bg="white"
-      width="100%"
-      maxHeight={`calc(100% - ${theme.space[4]}px)`}
-      maxWidth={326}
-      overflowY="auto"
-    >
-      <section aria-labelledby="heading-search">
-        <h2 id="heading-search">
-          <b>Search</b>
-        </h2>
+    <section aria-labelledby="heading-search">
+      <Media lessThan="md">
+        <VisuallyHidden>
+          <h2 id="heading-search">Search</h2>
+        </VisuallyHidden>
 
-        <Box mt={3}>
-          <LocationSearch onSelectedItemChange={onSelectedItemChange} />
-        </Box>
-      </section>
+        <Box position="absolute" top={0} left={0} p={3} width="100%">
+          <LocationSearch
+            onSelectedItemChange={(center) => onUpdateMapPosition({ center })}
+          />
 
-      <Box as="section" my={4} aria-labelledby="heading-filters">
-        <h2 id="heading-filters">
-          <VisuallyHidden>Filters</VisuallyHidden>
-        </h2>
-
-        <Box display="flex" justifyContent="space-between">
-          <Box
-            as="button"
-            type="button"
-            display="flex"
-            alignItems="center"
-            aria-expanded={isFilterExpanded}
-            onClick={() => setIsFilterExpanded(!isFilterExpanded)}
-          >
-            <Icon icon={faFilter} fixedWidth size="lg" />
-            <Box mx={2}>
-              <Text lineHeight={1}>
-                <b>Filter</b>
-              </Text>
-            </Box>
-            <Arrow isExpanded={isFilterExpanded} />
+          <Box display="flex" justifyContent="center" mt={3}>
+            <Button
+              ref={filterToggleRef}
+              variant="secondary"
+              icon={<FontAwesomeIcon icon={faFilter} />}
+              aria-expanded={isFiltersExpanded}
+              onClick={() => setIsFiltersExpanded(!isFiltersExpanded)}
+            >
+              Filter Map
+            </Button>
           </Box>
 
-          {isFilterExpanded && (
-            <Text fontSize={12}>
+          <Drawer visible={isFiltersExpanded} animateFrom="left">
+            <Box display="flex" justifyContent="space-between" mb={4}>
+              <Box display="flex" alignItems="flex-end">
+                <FontAwesomeIcon icon={faFilter} fixedWidth size="lg" />
+                <Box as="h2" mx={2}>
+                  <Text lineHeight={1}>
+                    <b>Filter</b>
+                  </Text>
+                </Box>
+              </Box>
+
+              <Text fontSize={12}>
+                <Box
+                  as="button"
+                  type="button"
+                  onClick={() => onFilterChange({})}
+                  border={0}
+                  borderBottom={2}
+                  borderStyle="solid"
+                >
+                  Reset Filter
+                </Box>
+              </Text>
+            </Box>
+
+            <Filters filters={filters} onFilterChange={onFilterChange} />
+
+            <Box display="flex" justifyContent="center" mt={4}>
+              <Button
+                onClick={() => {
+                  setIsFiltersExpanded(false);
+
+                  // return focus to the control that invoked the filter overlay
+                  filterToggleRef.current.focus();
+                }}
+                css={{
+                  width: '100%',
+                }}
+              >
+                Done
+              </Button>
+            </Box>
+          </Drawer>
+        </Box>
+      </Media>
+
+      <Media greaterThan="sm">
+        <Box
+          position="absolute"
+          top={3}
+          left={3}
+          p={4}
+          borderRadius={35}
+          bg="white"
+          width="100%"
+          maxHeight={`calc(100% - ${theme.space[4]}px)`}
+          maxWidth={326}
+          overflowY="auto"
+        >
+          <h2 id="heading-search">
+            <b>Search</b>
+          </h2>
+
+          <Box mt={3}>
+            <LocationSearch onSelectedItemChange={onSelectedItemChange} />
+          </Box>
+
+          <Box as="section" my={4} aria-labelledby="heading-filters">
+            <h2 id="heading-filters">
+              <VisuallyHidden>Filters</VisuallyHidden>
+            </h2>
+
+            <Box display="flex" justifyContent="space-between">
               <Box
                 as="button"
                 type="button"
-                onClick={() => onFilterChange({})}
-                border={0}
-                borderBottom={2}
-                borderStyle="solid"
+                display="flex"
+                alignItems="center"
+                aria-expanded={isFilterExpanded}
+                onClick={() => setIsFilterExpanded(!isFilterExpanded)}
               >
-                Reset Filter
+                <Icon icon={faFilter} fixedWidth size="lg" />
+                <Box mx={2}>
+                  <Text lineHeight={1}>
+                    <b>Filter</b>
+                  </Text>
+                </Box>
+                <Arrow isExpanded={isFilterExpanded} />
               </Box>
-            </Text>
-          )}
-        </Box>
 
-        <Box pt={4} hidden={!isFilterExpanded}>
-          <Filters filters={filters} onFilterChange={onFilterChange} />
-        </Box>
-      </Box>
+              {isFilterExpanded && (
+                <Text fontSize={12}>
+                  <Box
+                    as="button"
+                    type="button"
+                    onClick={() => onFilterChange({})}
+                    border={0}
+                    borderBottom={2}
+                    borderStyle="solid"
+                  >
+                    Reset Filter
+                  </Box>
+                </Text>
+              )}
+            </Box>
 
-      <Box as="section" mt={4} aria-labelledby="heading-add">
-        <h2 id="heading-add">
-          <VisuallyHidden>Add a toilet</VisuallyHidden>
-        </h2>
-        <StyledNavLink
-          to={`/loos/add?lat=${mapCenter.lat}&lng=${mapCenter.lng}`}
-        >
-          <Icon icon={faPlusCircle} fixedWidth size="lg" />
-          <Box mx={2}>
-            <Text lineHeight={1}>
-              <b>Add a Toilet</b>
-            </Text>
+            <Box pt={4} hidden={!isFilterExpanded}>
+              <Filters filters={filters} onFilterChange={onFilterChange} />
+            </Box>
           </Box>
-          <Arrow />
-        </StyledNavLink>
-      </Box>
-    </Box>
+
+          <Box as="section" mt={4} aria-labelledby="heading-add">
+            <h2 id="heading-add">
+              <VisuallyHidden>Add a toilet</VisuallyHidden>
+            </h2>
+            <StyledNavLink
+              to={`/loos/add?lat=${mapCenter.lat}&lng=${mapCenter.lng}`}
+            >
+              <Icon icon={faPlusCircle} fixedWidth size="lg" />
+              <Box mx={2}>
+                <Text lineHeight={1}>
+                  <b>Add a Toilet</b>
+                </Text>
+              </Box>
+              <Arrow />
+            </StyledNavLink>
+          </Box>
+        </Box>
+      </Media>
+    </section>
   );
 };
 
 Sidebar.propTypes = {
   filters: PropTypes.object.isRequired,
+  onUpdateMapPosition: PropTypes.func.isRequired,
   onFilterChange: PropTypes.func.isRequired,
   onSelectedItemChange: PropTypes.func.isRequired,
 };

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,7 +1,6 @@
 import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { useTheme } from 'emotion-theming';
 import isPropValid from '@emotion/is-prop-valid';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -51,7 +50,6 @@ const Sidebar = ({
   onUpdateMapPosition,
   mapCenter,
 }) => {
-  const theme = useTheme();
   const [isFilterExpanded, setIsFilterExpanded] = useState(false);
   const [isFiltersExpanded, setIsFiltersExpanded] = useState(false);
   const filterToggleRef = useRef(null);
@@ -63,82 +61,69 @@ const Sidebar = ({
           <h2 id="heading-search">Search</h2>
         </VisuallyHidden>
 
-        <Box position="absolute" top={0} left={0} p={3} width="100%">
-          <LocationSearch
-            onSelectedItemChange={(center) => onUpdateMapPosition({ center })}
-          />
+        <LocationSearch
+          onSelectedItemChange={(center) => onUpdateMapPosition({ center })}
+        />
 
-          <Box display="flex" justifyContent="center" mt={3}>
-            <Button
-              ref={filterToggleRef}
-              variant="secondary"
-              icon={<FontAwesomeIcon icon={faFilter} />}
-              aria-expanded={isFiltersExpanded}
-              onClick={() => setIsFiltersExpanded(!isFiltersExpanded)}
-            >
-              Filter Map
-            </Button>
+        <Box display="flex" justifyContent="center" mt={3}>
+          <Button
+            ref={filterToggleRef}
+            variant="secondary"
+            icon={<FontAwesomeIcon icon={faFilter} />}
+            aria-expanded={isFiltersExpanded}
+            onClick={() => setIsFiltersExpanded(!isFiltersExpanded)}
+          >
+            Filter Map
+          </Button>
+        </Box>
+
+        <Drawer visible={isFiltersExpanded} animateFrom="left">
+          <Box display="flex" justifyContent="space-between" mb={4}>
+            <Box display="flex" alignItems="flex-end">
+              <FontAwesomeIcon icon={faFilter} fixedWidth size="lg" />
+              <Box as="h2" mx={2}>
+                <Text lineHeight={1}>
+                  <b>Filter</b>
+                </Text>
+              </Box>
+            </Box>
+
+            <Text fontSize={12}>
+              <Box
+                as="button"
+                type="button"
+                onClick={() => onFilterChange({})}
+                border={0}
+                borderBottom={2}
+                borderStyle="solid"
+              >
+                Reset Filter
+              </Box>
+            </Text>
           </Box>
 
-          <Drawer visible={isFiltersExpanded} animateFrom="left">
-            <Box display="flex" justifyContent="space-between" mb={4}>
-              <Box display="flex" alignItems="flex-end">
-                <FontAwesomeIcon icon={faFilter} fixedWidth size="lg" />
-                <Box as="h2" mx={2}>
-                  <Text lineHeight={1}>
-                    <b>Filter</b>
-                  </Text>
-                </Box>
-              </Box>
+          <Filters filters={filters} onFilterChange={onFilterChange} />
 
-              <Text fontSize={12}>
-                <Box
-                  as="button"
-                  type="button"
-                  onClick={() => onFilterChange({})}
-                  border={0}
-                  borderBottom={2}
-                  borderStyle="solid"
-                >
-                  Reset Filter
-                </Box>
-              </Text>
-            </Box>
+          <Box display="flex" justifyContent="center" mt={4}>
+            <Button
+              onClick={() => {
+                setIsFiltersExpanded(false);
 
-            <Filters filters={filters} onFilterChange={onFilterChange} />
-
-            <Box display="flex" justifyContent="center" mt={4}>
-              <Button
-                onClick={() => {
-                  setIsFiltersExpanded(false);
-
-                  // return focus to the control that invoked the filter overlay
-                  filterToggleRef.current.focus();
-                }}
-                css={{
-                  width: '100%',
-                }}
-              >
-                Done
-              </Button>
-            </Box>
-          </Drawer>
-        </Box>
+                // return focus to the control that invoked the filter overlay
+                filterToggleRef.current.focus();
+              }}
+              css={{
+                width: '100%',
+              }}
+            >
+              Done
+            </Button>
+          </Box>
+        </Drawer>
       </Media>
 
       <Media greaterThan="sm">
-        <Box
-          position="absolute"
-          top={3}
-          left={3}
-          p={4}
-          borderRadius={35}
-          bg="white"
-          width="100%"
-          maxHeight={`calc(100% - ${theme.space[4]}px)`}
-          maxWidth={326}
-          overflowY="auto"
-        >
+        <Box p={4} borderRadius={35} bg="white" width="100%">
           <h2 id="heading-search">
             <b>Search</b>
           </h2>

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -114,6 +114,29 @@ const HomePage = ({ initialPosition, ...props }) => {
       </VisuallyHidden>
 
       <Box height="100%" display="flex" position="relative">
+        <Box
+          position="absolute"
+          zIndex={1}
+          top={0}
+          left={[0, 3]}
+          right={0}
+          bottom={0}
+          m={3}
+          maxWidth={326}
+          maxHeight="100%"
+          overflowY="auto"
+          // center on small viewports
+          mx={['auto', 0]}
+        >
+          <Sidebar
+            filters={filters}
+            onFilterChange={setFilters}
+            onSelectedItemChange={(center) => setMapPosition({ center })}
+            onUpdateMapPosition={setMapPosition}
+            mapCenter={mapPosition.center}
+          />
+        </Box>
+
         <LooMap
           loos={toilets.map((toilet) => {
             if (toilet.id === selectedLooId) {
@@ -128,14 +151,6 @@ const HomePage = ({ initialPosition, ...props }) => {
           zoom={mapPosition.zoom}
           onViewportChanged={setMapPosition}
           controlsOffset={toiletPanelDimensions.height}
-        />
-
-        <Sidebar
-          filters={filters}
-          onFilterChange={setFilters}
-          onSelectedItemChange={(center) => setMapPosition({ center })}
-          onUpdateMapPosition={setMapPosition}
-          mapCenter={mapPosition.center}
         />
 
         {Boolean(selectedLooId) && data && (

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,25 +1,17 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useParams, useRouteMatch } from 'react-router-dom';
 import queryString from 'query-string';
 import { Helmet } from 'react-helmet';
 import { loader } from 'graphql.macro';
 import { useQuery } from '@apollo/client';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faFilter } from '@fortawesome/free-solid-svg-icons';
 
-import { Media } from '../components/Media';
 import PageLayout from '../components/PageLayout';
 import LooMap from '../components/LooMap';
 import useMapPosition from '../components/useMapPosition';
 import useNearbyLoos from '../components/useNearbyLoos';
 import Box from '../components/Box';
 import ToiletDetailsPanel from '../components/ToiletDetailsPanel';
-import LocationSearch from '../components/LocationSearch';
-import Button from '../components/Button';
-import Drawer from '../components/Drawer';
-import Filters from '../components/Filters';
-import Text from '../components/Text';
 import Sidebar from '../components/Sidebar';
 import Notification from '../components/Notification';
 import VisuallyHidden from '../components/VisuallyHidden';
@@ -30,8 +22,6 @@ const FIND_BY_ID = loader('./findLooById.graphql');
 
 const HomePage = ({ initialPosition, ...props }) => {
   const [mapPosition, setMapPosition] = useMapPosition(config.fallbackLocation);
-  const [isFiltersExpanded, setIsFiltersExpanded] = useState(false);
-  const filterToggleRef = useRef(null);
 
   let initialState = config.getSettings(FILTERS_KEY);
 
@@ -140,80 +130,13 @@ const HomePage = ({ initialPosition, ...props }) => {
           controlsOffset={toiletPanelDimensions.height}
         />
 
-        <section>
-          <Media lessThan="md">
-            <Box position="absolute" top={0} left={0} p={3} width="100%">
-              <LocationSearch
-                onSelectedItemChange={(center) => setMapPosition({ center })}
-              />
-
-              <Box display="flex" justifyContent="center" mt={3}>
-                <Button
-                  ref={filterToggleRef}
-                  variant="secondary"
-                  icon={<FontAwesomeIcon icon={faFilter} />}
-                  aria-expanded={isFiltersExpanded}
-                  onClick={() => setIsFiltersExpanded(!isFiltersExpanded)}
-                >
-                  Filter Map
-                </Button>
-              </Box>
-
-              <Drawer visible={isFiltersExpanded} animateFrom="left">
-                <Box display="flex" justifyContent="space-between" mb={4}>
-                  <Box display="flex" alignItems="flex-end">
-                    <FontAwesomeIcon icon={faFilter} fixedWidth size="lg" />
-                    <Box as="h2" mx={2}>
-                      <Text lineHeight={1}>
-                        <b>Filter</b>
-                      </Text>
-                    </Box>
-                  </Box>
-
-                  <Text fontSize={12}>
-                    <Box
-                      as="button"
-                      type="button"
-                      onClick={() => setFilters({})}
-                      border={0}
-                      borderBottom={2}
-                      borderStyle="solid"
-                    >
-                      Reset Filter
-                    </Box>
-                  </Text>
-                </Box>
-
-                <Filters filters={filters} onFilterChange={setFilters} />
-
-                <Box display="flex" justifyContent="center" mt={4}>
-                  <Button
-                    onClick={() => {
-                      setIsFiltersExpanded(false);
-
-                      // return focus to the control that invoked the filter overlay
-                      filterToggleRef.current.focus();
-                    }}
-                    css={{
-                      width: '100%',
-                    }}
-                  >
-                    Done
-                  </Button>
-                </Box>
-              </Drawer>
-            </Box>
-          </Media>
-
-          <Media greaterThan="sm">
-            <Sidebar
-              filters={filters}
-              onFilterChange={setFilters}
-              onSelectedItemChange={(center) => setMapPosition({ center })}
-              mapCenter={mapPosition.center}
-            />
-          </Media>
-        </section>
+        <Sidebar
+          filters={filters}
+          onFilterChange={setFilters}
+          onSelectedItemChange={(center) => setMapPosition({ center })}
+          onUpdateMapPosition={setMapPosition}
+          mapCenter={mapPosition.center}
+        />
 
         {Boolean(selectedLooId) && data && (
           <Box


### PR DESCRIPTION
Accessibility improvement which changes the tab order so that the search/filter controls will be focused before the map.

Includes https://github.com/neontribe/gbptm/pull/729