### PR TITLE
fix: persist map controls focus outline

### DIFF
--- a/src/components/LooMap/LooMap.js
+++ b/src/components/LooMap/LooMap.js
@@ -160,6 +160,7 @@ const LooMap = ({
           }
 
           :focus,
+          .leaflet-control a:focus,
           .leaflet-marker-icon:focus {
             outline: 2px solid ${theme.colors.tertiary} !important;
             outline-offset: 0.5rem;


### PR DESCRIPTION
The focus outline was only appearing briefly before fading away.