### PR TITLE
fix: skip find loo by id query

### DIFF
--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -48,9 +48,9 @@ const HomePage = ({ initialPosition, ...props }) => {
   const selectedLooId = useParams().id;
 
   const { data, loading } = useQuery(FIND_BY_ID, {
+    skip: !selectedLooId,
     variables: {
       id: selectedLooId,
-      skip: !selectedLooId,
     },
   });
 


### PR DESCRIPTION
this will reduce the number of initital requests on the home page by one