### PR TITLE
fix: update map center on add page

### DIFF
--- a/src/pages/AddPage.js
+++ b/src/pages/AddPage.js
@@ -96,6 +96,7 @@ const AddPage = (props) => {
           showCrosshair
           controlsOffset={20}
           withAccessibilityOverlays={false}
+          onViewportChanged={setMapPosition}
         />
 
         <Box position="absolute" top={0} left={0} m={3}>


### PR DESCRIPTION
Updates map center when the map moves to ensure the selected loo location is added to the mutation variables

Fixes #769