### PR TITLE
fix: update add and edit page appearance

### DIFF
--- a/src/components/EntryForm.js
+++ b/src/components/EntryForm.js
@@ -282,11 +282,9 @@ const EntryForm = ({ title, loo, center, children, ...props }) => {
     <Container maxWidth={846}>
       <Text fontSize={[16, 18]}>
         <form onSubmit={handleSubmit(onSubmit)}>
-          <Text fontWeight="bold" fontSize={30} textAlign="center">
+          <VisuallyHidden>
             <h1>{title}</h1>
-          </Text>
-
-          <Spacer mt={4} />
+          </VisuallyHidden>
 
           <Box display="flex" alignItems="center" flexWrap="wrap">
             <span>1. Align the crosshair&nbsp;</span>

--- a/src/pages/AddPage.js
+++ b/src/pages/AddPage.js
@@ -83,7 +83,7 @@ const AddPage = (props) => {
         <title>{config.getTitle('Add Toilet')}</title>
       </Helmet>
 
-      <Box position="relative" display="flex" height={332} maxHeight="40vh">
+      <Box position="relative" display="flex" height="40vh">
         <LooMap
           loos={data}
           center={mapPosition.center}
@@ -105,23 +105,23 @@ const AddPage = (props) => {
         </Box>
       </Box>
 
-      <Box position="relative" mt={-3} pt={4} borderRadius={35} bg="white">
-        <EntryForm
-          title="Add This Toilet"
-          loo={initialFormState}
-          center={mapPosition.center}
-          saveLoading={saveLoading}
-          saveResponse={saveResponse}
-          saveError={saveError}
-          onSubmit={save}
-        >
-          <Box display="flex" flexDirection="column" alignItems="center">
-            <Button type="submit" data-testid="add-the-toilet">
-              Save toilet
-            </Button>
-          </Box>
-        </EntryForm>
-      </Box>
+      <Spacer mt={4} />
+
+      <EntryForm
+        title="Add This Toilet"
+        loo={initialFormState}
+        center={mapPosition.center}
+        saveLoading={saveLoading}
+        saveResponse={saveResponse}
+        saveError={saveError}
+        onSubmit={save}
+      >
+        <Box display="flex" flexDirection="column" alignItems="center">
+          <Button type="submit" data-testid="add-the-toilet">
+            Save toilet
+          </Button>
+        </Box>
+      </EntryForm>
 
       <Spacer mt={4} />
     </PageLayout>

--- a/src/pages/EditPage.js
+++ b/src/pages/EditPage.js
@@ -151,7 +151,7 @@ const EditPage = (props) => {
         <title>{config.getTitle('Edit Toilet')}</title>
       </Helmet>
 
-      <Box display="flex" height={332} maxHeight="40vh">
+      <Box display="flex" height="40vh">
         <LooMap
           loos={getLoosToDisplay()}
           center={mapPosition.center}
@@ -169,43 +169,43 @@ const EditPage = (props) => {
         />
       </Box>
 
-      <Box position="relative" mt={-3} pt={4} borderRadius={35} bg="white">
-        <EntryForm
-          title="Edit This Toilet"
-          loo={initialData.loo}
-          center={mapCenter}
-          saveLoading={saveLoading}
-          saveResponse={saveResponse}
-          saveError={saveError}
-          onSubmit={save}
-        >
-          {({ hasDirtyFields }) => (
-            <Box display="flex" flexDirection="column" alignItems="center">
-              <Button
-                type="submit"
-                disabled={!hasDirtyFields}
-                css={{
-                  width: '100%',
-                }}
-              >
-                Update the toilet
-              </Button>
+      <Spacer mt={4} />
 
-              <Spacer mt={2} />
+      <EntryForm
+        title="Edit This Toilet"
+        loo={initialData.loo}
+        center={mapCenter}
+        saveLoading={saveLoading}
+        saveResponse={saveResponse}
+        saveError={saveError}
+        onSubmit={save}
+      >
+        {({ hasDirtyFields }) => (
+          <Box display="flex" flexDirection="column" alignItems="center">
+            <Button
+              type="submit"
+              disabled={!hasDirtyFields}
+              css={{
+                width: '100%',
+              }}
+            >
+              Update the toilet
+            </Button>
 
-              <Button
-                as={Link}
-                to={`/loos/${props.match.params.id}/remove`}
-                css={{
-                  width: '100%',
-                }}
-              >
-                Remove the toilet
-              </Button>
-            </Box>
-          )}
-        </EntryForm>
-      </Box>
+            <Spacer mt={2} />
+
+            <Button
+              as={Link}
+              to={`/loos/${props.match.params.id}/remove`}
+              css={{
+                width: '100%',
+              }}
+            >
+              Remove the toilet
+            </Button>
+          </Box>
+        )}
+      </EntryForm>
 
       <Spacer mt={4} />
     </PageLayout>


### PR DESCRIPTION
Fixes #762 

Worked with Rachel to make the following changes:
> * Adjusting it so that the map takes up a higher % of the viewpoirt height helps with the 'lots of white space' part of the problem.
> * Removing the corners deals with the misconception of the form 'masking' the map.
> * Removing the title then permits the user to still view the initial content of the form before it gets cut off at the viewport height.