### PR TITLE
 fix: load all map tiles for Safari browser

### DIFF
--- a/src/components/LooMap/LooMap.js
+++ b/src/components/LooMap/LooMap.js
@@ -43,7 +43,8 @@ const LooMap = ({
   const [announcement, setAnnouncement] = React.useState(null);
 
   useEffect(() => {
-    const map = mapRef.current.leafletElement.getContainer();
+    const { leafletElement } = mapRef.current;
+    const map = leafletElement.getContainer();
 
     // when focused on the map container, Leaflet allows the user to pan the map by using the arrow keys
     // without the application role screen reader software overrides these controls
@@ -51,6 +52,12 @@ const LooMap = ({
     // this also avoids the entire main region being announced
     map.setAttribute('role', 'application');
     map.setAttribute('aria-label', 'Map');
+
+    // ensure all map tiles are loaded on Safari
+    // https://github.com/neontribe/gbptm/issues/776
+    setTimeout(() => {
+      leafletElement.invalidateSize();
+    }, 400);
   }, []);
 
   const handleViewportChanged = () => {

--- a/src/explorer/explorer.module.css
+++ b/src/explorer/explorer.module.css
@@ -22,7 +22,5 @@ body {
 }
 
 :global(.leaflet-container) {
-  height: 100%;
-  width: 100%;
   z-index: 0;
 }


### PR DESCRIPTION
~Can't reproduce locally so I'm testing against now.sh.~

This is the best/only solution I could find :/

Fixes #776 