### PR TITLE
feat: list all toilet features in details panel

### DIFF
--- a/src/components/ToiletDetailsPanel.js
+++ b/src/components/ToiletDetailsPanel.js
@@ -10,6 +10,9 @@ import {
   faPoundSign,
   faBaby,
   faToilet,
+  faMale,
+  faFemale,
+  faChild,
   faKey,
   faCog,
   faQuestion,
@@ -232,6 +235,26 @@ const ToiletDetailsPanel = ({
       icon: <Icon icon={faToilet} />,
       label: 'Gender Neutral',
       valueIcon: getFeatureValueIcon(data.allGender),
+    },
+    {
+      icon: <Icon icon={faFemale} />,
+      label: 'Female Toilets',
+      valueIcon: getFeatureValueIcon(data.female),
+    },
+    {
+      icon: <Icon icon={faMale} />,
+      label: 'Male Toilets',
+      valueIcon: getFeatureValueIcon(data.male),
+    },
+    {
+      icon: <Icon icon={faChild} />,
+      label: 'Children Only',
+      valueIcon: getFeatureValueIcon(data.childrenOnly),
+    },
+    {
+      icon: <Icon icon={faToilet} />,
+      label: 'Urinal Only',
+      valueIcon: getFeatureValueIcon(data.urinalOnly),
     },
     {
       icon: <Icon icon={faCog} />,


### PR DESCRIPTION
I'm not sure if we want these in a specific order.

Note that the "Urinal Only" duplicates the icon for "Gender Neutral".

Fixes #764

![toilet-features](https://user-images.githubusercontent.com/847033/84183614-156b9b00-aa84-11ea-9770-d4d062414ae4.png)