### PR TITLE
fix: avoid invalidateSize error

### DIFF
--- a/src/components/LooMap/LooMap.js
+++ b/src/components/LooMap/LooMap.js
@@ -56,7 +56,9 @@ const LooMap = ({
     // ensure all map tiles are loaded on Safari
     // https://github.com/neontribe/gbptm/issues/776
     setTimeout(() => {
-      leafletElement.invalidateSize();
+      leafletElement.invalidateSize({
+        pan: false,
+      });
     }, 400);
   }, []);
 


### PR DESCRIPTION
Avoids the following error when first arriving on a toilet edit page:
> DomUtil.js:247 Uncaught TypeError: Cannot read property '_leaflet_pos' of undefined