### PR TITLE
feat: use nominatim geocoder for search

### DIFF
--- a/src/components/LocationSearch/LocationSearch.js
+++ b/src/components/LocationSearch/LocationSearch.js
@@ -10,7 +10,7 @@ import { faSearch, faTimes } from '@fortawesome/free-solid-svg-icons';
 import Box from '../Box';
 import VisuallyHidden from '../VisuallyHidden';
 
-import usePlacesAutocomplete from './usePlacesAutocomplete';
+import useNominatimAutocomplete from './useNominatimAutocomplete';
 
 import poweredByGoogle from './powered_by_google.png';
 
@@ -28,17 +28,16 @@ const LocationSearch = ({ onSelectedItemChange }) => {
   const [query, setQuery] = React.useState('');
   const theme = useTheme();
 
-  const { places, getPlaceById } = usePlacesAutocomplete(query);
+  const { places, getPlaceLatLng } = useNominatimAutocomplete(query);
 
   const handleSelectedItemChange = async ({ selectedItem }) => {
     if (!selectedItem) {
       return;
     }
 
-    const result = await getPlaceById(selectedItem.placeId);
-    const { lat, lng } = result.geometry.location;
+    const { lat, lng } = await getPlaceLatLng(selectedItem);
 
-    onSelectedItemChange({ lat: lat(), lng: lng() });
+    onSelectedItemChange({ lat, lng });
   };
 
   const stateReducer = (state, actionAndChanges) => {
@@ -82,7 +81,7 @@ const LocationSearch = ({ onSelectedItemChange }) => {
   } = useCombobox({
     items: places,
     onInputValueChange: ({ inputValue }) => setQuery(inputValue),
-    itemToString: (item) => (item ? `${item.label}, ${item.subLabel}` : ''),
+    itemToString: (item) => (item ? item.label : ''),
     onSelectedItemChange: handleSelectedItemChange,
     stateReducer,
   });
@@ -174,7 +173,7 @@ const LocationSearch = ({ onSelectedItemChange }) => {
                     }}
                     {...getItemProps({ item, index })}
                   >
-                    <span>{item.label}</span> {item.subLabel}
+                    <span>{item.label}</span>
                   </Box>
                 ))
               : 'No results found'}

--- a/src/components/LocationSearch/LocationSearch.js
+++ b/src/components/LocationSearch/LocationSearch.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Helmet } from 'react-helmet';
 import { useCombobox } from 'downshift';
 import { useTheme } from 'emotion-theming';
 import styled from '@emotion/styled';
@@ -11,8 +10,6 @@ import Box from '../Box';
 import VisuallyHidden from '../VisuallyHidden';
 
 import useNominatimAutocomplete from './useNominatimAutocomplete';
-
-import poweredByGoogle from './powered_by_google.png';
 
 const Input = styled.input(
   ({ theme }) => `
@@ -88,12 +85,6 @@ const LocationSearch = ({ onSelectedItemChange }) => {
 
   return (
     <>
-      <Helmet>
-        <script
-          src={`https://maps.googleapis.com/maps/api/js?key=${process.env.REACT_APP_GOOGLE_MAPS_API_KEY}&libraries=places`}
-        />
-      </Helmet>
-
       <VisuallyHidden>
         <label {...getLabelProps()}>Search for a location</label>
       </VisuallyHidden>
@@ -177,14 +168,6 @@ const LocationSearch = ({ onSelectedItemChange }) => {
                   </Box>
                 ))
               : 'No results found'}
-
-            <Box
-              as="img"
-              src={poweredByGoogle}
-              alt="Powered by Google"
-              mt={3}
-              maxWidth={120}
-            />
           </>
         )}
       </Box>

--- a/src/components/LocationSearch/useNominatimAutocomplete.js
+++ b/src/components/LocationSearch/useNominatimAutocomplete.js
@@ -6,7 +6,7 @@ const useNominatimAutocomplete = (input) => {
 
   const fetchPlaces = React.useCallback(
     debounce(async (input) => {
-      const fetchUrl = `https://nominatim.openstreetmap.org/search?q=${input}&limit=5&format=json`;
+      const fetchUrl = `https://nominatim.openstreetmap.org/search?q=${input}&countrycodes=gb&limit=5&format=json`;
 
       const response = await fetch(fetchUrl);
       const results = await response.json();

--- a/src/components/LocationSearch/useNominatimAutocomplete.js
+++ b/src/components/LocationSearch/useNominatimAutocomplete.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import debounce from 'lodash/debounce';
+
+const useNominatimAutocomplete = (input) => {
+  const [places, setPlaces] = React.useState([]);
+
+  const fetchPlaces = React.useCallback(
+    debounce(async (input) => {
+      const fetchUrl = `https://nominatim.openstreetmap.org/search?q=${input}&limit=5&format=json`;
+
+      const response = await fetch(fetchUrl);
+      const results = await response.json();
+
+      if (!results) {
+        return;
+      }
+
+      const locationResults = results.map((item) => ({
+        id: item.place_id,
+        label: item.display_name,
+        location: {
+          lat: item.lat,
+          lng: item.lon,
+        },
+      }));
+
+      setPlaces(locationResults);
+    }, 300),
+    []
+  );
+
+  // Fetch places when input changes
+  React.useEffect(() => {
+    if (input.length < 3) {
+      return;
+    }
+
+    fetchPlaces(input);
+  }, [input, fetchPlaces]);
+
+  // Clear places when input is cleared
+  React.useEffect(() => {
+    if (input) {
+      return;
+    }
+
+    setPlaces([]);
+  }, [input, setPlaces]);
+
+  const getPlaceLatLng = ({ location }) => {
+    return {
+      lat: parseFloat(location.lat),
+      lng: parseFloat(location.lng),
+    };
+  };
+
+  return { places, getPlaceLatLng };
+};
+
+export default useNominatimAutocomplete;

--- a/src/components/LocationSearch/usePlacesAutocomplete.js
+++ b/src/components/LocationSearch/usePlacesAutocomplete.js
@@ -60,8 +60,7 @@ const usePlacesAutocomplete = (input) => {
         const locationResults = places.map((item) => ({
           id: item.id,
           placeId: item.place_id,
-          label: item.structured_formatting.main_text,
-          subLabel: item.structured_formatting.secondary_text,
+          label: `${item.structured_formatting.main_text}, ${item.structured_formatting.secondary_text}`,
         }));
 
         setPlaces(locationResults);
@@ -93,7 +92,7 @@ const usePlacesAutocomplete = (input) => {
     setPlaces([]);
   }, [input, setPlaces]);
 
-  const getPlaceById = (placeId) => {
+  const getPlaceLatLng = ({ placeId }) => {
     // PlacesService expects an HTML (normally a map) element
     // https://developers.google.com/maps/documentation/javascript/reference/places-service#library
     const placesService = new window.google.maps.places.PlacesService(
@@ -103,7 +102,7 @@ const usePlacesAutocomplete = (input) => {
     const OK = window.google.maps.places.PlacesServiceStatus.OK;
 
     return new Promise((resolve, reject) => {
-      placesService.getDetails({ placeId, sessionToken }, (results, status) => {
+      placesService.getDetails({ placeId, sessionToken }, (result, status) => {
         if (status !== OK) {
           reject(status);
           return;
@@ -113,12 +112,14 @@ const usePlacesAutocomplete = (input) => {
         // https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompleteSessionToken
         resetSessionToken();
 
-        resolve(results);
+        const { lat, lng } = result.geometry.location;
+
+        resolve({ lat: lat(), lng: lng() });
       });
     });
   };
 
-  return { places, getPlaceById };
+  return { places, getPlaceLatLng };
 };
 
 export default usePlacesAutocomplete;


### PR DESCRIPTION
Something's not working with the Google Places session tokens which is making the cost unsustainable. This PR reverts to using the Nominatim geocoder for our search results.

- adds a `useNominatimAutocomplete` hook to fetch search results based on the query input
- swaps `useNominatimAutocomplete` for `usePlacesAutocomplete`
- tweaks `usePlacesAutocomplete` to make the API more similar to `useNominatimAutocomplete` and generic which should mean future search provider changes will not require changes to the `LocationSearch` component itself