### PR TITLE
feat: add plausible events

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -47,6 +47,7 @@
       content="The Great British Public Toilet Map is the UK's largest database of publicly-accessible toilets, with over 11000 facilities."
     />
     <script async defer data-domain="toiletmap.org.uk" src="https://stats.toiletmap.org.uk/js/index.js"></script>
+    <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
   <body>
     <noscript>

--- a/src/components/LocationSearch/LocationSearch.js
+++ b/src/components/LocationSearch/LocationSearch.js
@@ -31,9 +31,9 @@ const LocationSearch = ({ onSelectedItemChange }) => {
     if (!selectedItem) {
       return;
     }
-
+    window.plausible('Search'); 
     const { lat, lng } = await getPlaceLatLng(selectedItem);
-
+    
     onSelectedItemChange({ lat, lng });
   };
 

--- a/src/components/LooMap/LocateMapControl.js
+++ b/src/components/LooMap/LocateMapControl.js
@@ -58,11 +58,20 @@ const LocateMapControl = ({ position }) => {
     onStopLocation,
   });
 
+  const handleClick = () => {
+    if (!isActive) {
+      startLocate();
+      window.plausible('Geolocate'); 
+    } else {
+      stopLocate()
+    }
+  }; 
+
   return (
     <Control position={position}>
       <ControlButton
         type="button"
-        onClick={() => (isActive ? stopLocate() : startLocate())}
+        onClick={handleClick}
         aria-label="Locate my position"
         variant={isActive && 'active'}
       >


### PR DESCRIPTION
Adding plausible events to see how many users are searching or using geolocate to find toilets.

Related to issue #1032. We want to double check our assumption that users are finding it hard to find toilets near them, and aren't using geolocate.