### PR TITLE
Cookies Page, Small layout fix

### DIFF
--- a/src/components/EntryForm.tsx
+++ b/src/components/EntryForm.tsx
@@ -604,7 +604,6 @@ const EntryForm = ({ title, loo, center, children, ...props }) => {
                 that are hidden in high street cafes, restaurants, coffee shops
                 and bars.&nbsp;
                 <Button
-                  as={Link}
                   href="/use-our-loos"
                   variant="link"
                   aria-label="Read more about the Use Our Loos Campaign"

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Link from 'next/link';
 
 import PageLayout from '../components/PageLayout';
 import Box from '../components/Box';
@@ -32,7 +31,7 @@ const NotFound = () => (
 
         <Spacer mt={4} />
 
-        <Button as={Link} href="/">
+        <Button as={'a'} variant="link" href="/">
           Take me back home!
         </Button>
       </div>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -27,6 +27,11 @@ class MyDocument extends Document {
         <body>
           <Main />
           <NextScript />
+          <style>{`
+            #__next {
+              height: 100%;
+            }
+          `}</style>
           <title>The Great British Public Toilet Map</title>
           <meta
             name="Description"

--- a/src/pages/cookies.tsx
+++ b/src/pages/cookies.tsx
@@ -27,7 +27,7 @@ const CookiesPage = () => (
       </p>
       <p>
         For more detailed information about the cookies we use, see our{' '}
-        <Button as={Link} variant="link" to="/privacy">
+        <Button as={'a'} variant="link" href="/privacy">
           privacy policy.
         </Button>
       </p>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -48,7 +48,7 @@ const HomePage = () => {
         <h1>{pageTitle}</h1>
       </VisuallyHidden>
 
-      <Box height="100vh" display="flex" position="relative">
+      <Box height="100%" display="flex" position="relative">
         <Box
           position="absolute"
           zIndex={1}


### PR DESCRIPTION
* Uncomment cookies page
* Change some links so that they're underlined
* Fix the page height of `__next` wrapper so that we don't have scroll bars on desktop anymore