### PR TITLE
Fix highlighted day off by one error

### DIFF
--- a/src/components/ToiletDetailsPanel.js
+++ b/src/components/ToiletDetailsPanel.js
@@ -144,10 +144,8 @@ const ToiletDetailsPanel = ({
 }) => {
   const [isExpanded, setIsExpanded] = React.useState(startExpanded);
 
-  const [
-    submitVerificationMutation,
-    { loading: submitVerificationLoading },
-  ] = useMutation(SUBMIT_VERIFICATION_REPORT_MUTATION);
+  const [submitVerificationMutation, { loading: submitVerificationLoading }] =
+    useMutation(SUBMIT_VERIFICATION_REPORT_MUTATION);
 
   const submitVerificationReport = async (variables) => {
     const responseData = await submitVerificationMutation(variables);
@@ -518,7 +516,7 @@ const ToiletDetailsPanel = ({
                     justifyContent="space-between"
                     key={i}
                     padding={1}
-                    bg={i === todayWeekdayIndex ? 'ice' : 'white'}
+                    bg={i === todayWeekdayIndex - 1 ? 'ice' : 'white'}
                   >
                     <span>{WEEKDAYS[i]}</span>
                     <span>{getTimeRangeLabel(timeRange)}</span>


### PR DESCRIPTION
## What does this change?
This fixes a problem where the currently highlighted day on the toilet details panel was off by one, meaning that the wrong day was highlighted

## Pictures (taken on a Friday)

| Before  | After |
| ------------- | ------------- |
| <img width="1084" alt="Screenshot 2021-12-24 at 21 34 18" src="https://user-images.githubusercontent.com/1771189/147372726-1d493028-de9d-45f5-b778-b1ca27ed9626.png"> | <img width="1076" alt="Screenshot 2021-12-24 at 21 33 58" src="https://user-images.githubusercontent.com/1771189/147372731-df56020a-6e57-4d2b-b200-5bca621eb67b.png"> |
