### PR TITLE
Fix accessiblity overlay

### DIFF
--- a/src/api-client/operations/findLooNamesByIds.graphql
+++ b/src/api-client/operations/findLooNamesByIds.graphql
@@ -1,0 +1,6 @@
+query looNamesByIds($idList: [ID]) {
+  looNamesByIds(idList: $idList) {
+    id
+    name
+  }
+}

--- a/src/api/resolvers.ts
+++ b/src/api/resolvers.ts
@@ -1,5 +1,6 @@
 import { stringifyAndCompressLoos } from '../lib/loo';
 import ngeohash from 'ngeohash';
+import { async } from 'hasha';
 
 const { Loo, Report, Area, MapGeo } = require('./db');
 const { GraphQLDateTime } = require('graphql-iso-date');
@@ -102,6 +103,8 @@ const resolvers = {
         page: res.page,
       };
     },
+    looNamesByIds: async (parent, args) =>
+      await Loo.find({ _id: { $in: args.idList } }),
     loosByProximity: async (parent, args) =>
       await Loo.findNear(args.from.lng, args.from.lat, args.from.maxDistance),
     loosByGeohash: async (parent, args, context) => {

--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -203,6 +203,7 @@ type Query {
     "A Point from which to begin the search"
     from: ProximityInput!
   ): [Loo!]!
+  looNamesByIds(idList: [ID]): [Loo!]!
   ukLooMarkers: [String!]! @cacheControl(maxAge: 360, scope: PUBLIC)
   "Retrieve a list of areas in existance, name and type only"
   areas: [AdminGeo!]!

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -27,7 +27,7 @@ const iconMap = {
 
 const Filters: React.FC = () => {
   const [mapState, setMapState] = useMapState();
-  const { filters } = mapState;
+  const { appliedFilters: filters } = mapState;
   return (
     <ul>
       {config.filters.map(({ id, label }, index) => (
@@ -53,7 +53,7 @@ const Filters: React.FC = () => {
             onClick={() => {
               setMapState({
                 ...mapState,
-                filters: {
+                appliedFilters: {
                   ...filters,
                   [id]: !filters[id],
                 },

--- a/src/components/LooMap/AccessibilityIntersection.tsx
+++ b/src/components/LooMap/AccessibilityIntersection.tsx
@@ -1,50 +1,57 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Rectangle } from 'react-leaflet';
+import { Rectangle, useMap } from 'react-leaflet';
+import { CompressedLooObject } from '../../lib/loo';
 
 // 0-5
 // https://github.com/Leaflet/Leaflet/issues/5766
 const KEY_CODES = [48, 49, 50, 51, 52, 53];
 
 const AccessibilityIntersection = ({
-  toilets = [],
+  toilets,
   center,
   onIntersection,
   onSelection,
   ...props
+}: {
+  toilets: CompressedLooObject[];
+  center: { lat: number; lng: number };
+  onIntersection: () => void;
+  onSelection: () => void;
 }) => {
+  const map = useMap();
   const rectangleRef = useRef(null);
-
   useEffect(() => {
-    const rectangle = rectangleRef.current.leafletElement;
+    const rectangle = rectangleRef.current;
+
     const contains = toilets
-      .filter((toilet: { location: any }) =>
-        rectangle.getBounds().contains(toilet.location)
+      .filter(
+        (toilet) => toilet && rectangle?.getBounds().contains(toilet.location)
       )
       .slice(0, KEY_CODES.length);
 
     onIntersection(contains);
   }, [center, toilets, onIntersection]);
-
   useEffect(() => {
     const keyDownHandler = (event: { keyCode: number }) => {
       const selectionIndex = KEY_CODES.indexOf(event.keyCode);
-
       if (selectionIndex === -1) {
         return;
       }
 
       onSelection(selectionIndex);
     };
-
     document.addEventListener('keydown', keyDownHandler);
-
     return () => {
       document.removeEventListener('keydown', keyDownHandler);
     };
   }, [onSelection]);
-
-  return <Rectangle bounds={null} ref={rectangleRef} {...props}></Rectangle>;
+  return (
+    <Rectangle
+      bounds={map?.getBounds().pad(-0.4)}
+      ref={rectangleRef}
+    ></Rectangle>
+  );
 };
 
 AccessibilityIntersection.propTypes = {

--- a/src/components/LooMap/AccessibilityList.tsx
+++ b/src/components/LooMap/AccessibilityList.tsx
@@ -84,10 +84,15 @@ const Content = ({ toilets }) => {
   );
 };
 
-const AccessibilityList = ({ toilets, ...props }) => {
+const AccessibilityList = ({
+  toilets,
+  ...props
+}: {
+  toilets: CompressedLooObject[];
+}) => {
   const [showContent, setShowContent] = React.useState(false);
 
-  // Fetch proper loo names
+  // Fetch loo names
   const unorderedNames = useLooNamesByIdsQuery({
     variables: { idList: toilets.map((t) => t?.id) },
   });
@@ -99,11 +104,11 @@ const AccessibilityList = ({ toilets, ...props }) => {
     }, 300);
   }, []);
 
-  const mapIdToName = Object.fromEntries(
+  const nameMap = Object.fromEntries(
     unorderedNames.data?.looNamesByIds.map((e) => [e.id, e.name]) || []
   );
 
-  const names = toilets.map((t) => mapIdToName[t?.id] || 'Toilet Loading');
+  const names = toilets.map((t) => nameMap[t?.id] || 'Name Unknown');
 
   return (
     <div

--- a/src/components/LooMap/AccessibilityList.tsx
+++ b/src/components/LooMap/AccessibilityList.tsx
@@ -5,6 +5,8 @@ import { useTheme, css } from '@emotion/react';
 import Box from '../Box';
 import Text from '../Text';
 import Spacer from '../Spacer';
+import { CompressedLooObject } from '../../lib/loo';
+import { useLooNamesByIdsQuery } from '../../api-client/graphql';
 
 const Key = ({ children, ...props }) => (
   <Box
@@ -82,10 +84,13 @@ const Content = ({ toilets }) => {
   );
 };
 
-const AccessibilityList = (
-  props: JSX.IntrinsicAttributes & { toilets: any }
-) => {
+const AccessibilityList = ({ toilets, ...props }) => {
   const [showContent, setShowContent] = React.useState(false);
+
+  // Fetch proper loo names
+  const unorderedNames = useLooNamesByIdsQuery({
+    variables: { idList: toilets.map((t) => t?.id) },
+  });
 
   // to ensure it gets announced, there must be a delay between the existence of the aria live element and the content
   useEffect(() => {
@@ -94,6 +99,12 @@ const AccessibilityList = (
     }, 300);
   }, []);
 
+  const mapIdToName = Object.fromEntries(
+    unorderedNames.data?.looNamesByIds.map((e) => [e.id, e.name]) || []
+  );
+
+  const names = toilets.map((t) => mapIdToName[t?.id] || 'Toilet Loading');
+
   return (
     <div
       role="status"
@@ -101,7 +112,7 @@ const AccessibilityList = (
       aria-live="polite"
       aria-relevant="additions text"
     >
-      {showContent && <Content {...props} />}
+      {showContent && <Content toilets={names || []} {...props} />}
     </div>
   );
 };

--- a/src/components/LooMap/LooMap.tsx
+++ b/src/components/LooMap/LooMap.tsx
@@ -268,11 +268,7 @@ const LooMap: React.FC<LooMapProps> = ({
               center={center}
             />
 
-            <AccessibilityList
-              toilets={intersectingToilets.map(
-                (toilet: { name: any }) => toilet.name
-              )}
-            />
+            <AccessibilityList toilets={intersectingToilets} />
 
             <VisuallyHidden>
               <div

--- a/src/components/LooMap/LooMap.tsx
+++ b/src/components/LooMap/LooMap.tsx
@@ -20,6 +20,8 @@ import AccessibilityList from './AccessibilityList';
 import VisuallyHidden from '../VisuallyHidden';
 import { Loo } from '../../api-client/graphql';
 import { CompressedLooObject } from '../../lib/loo';
+import React from 'react';
+import router from 'next/router';
 
 const MapTracker = () => {
   const [, setMapState] = useMapState();
@@ -60,11 +62,24 @@ const LooMap: React.FC<LooMapProps> = ({
   const [hydratedToilets, setHydratedToilets] = useState<CompressedLooObject[]>(
     []
   );
+  const [announcement, setAnnouncement] = React.useState(null);
   const [intersectingToilets, setIntersectingToilets] = useState([]);
   const [renderAccessibilityOverlays, setRenderAccessibilityOverlays] =
     useState(false);
 
-  console.log(intersectingToilets);
+  const keyboardSelectionHandler = React.useCallback(
+    (selectionIndex: string | number) => {
+      const toilet = intersectingToilets[selectionIndex];
+
+      if (!toilet) {
+        return;
+      }
+
+      setAnnouncement(`${toilet.name || 'Unnamed toilet'} selected`);
+      router.push(`/loos/${toilet.id}`);
+    },
+    [intersectingToilets]
+  );
 
   useEffect(() => {
     const loadedLooValues = Array.from(loadedToilets.values()).flatMap(
@@ -249,17 +264,17 @@ const LooMap: React.FC<LooMapProps> = ({
               className="accessibility-box"
               toilets={hydratedToilets}
               onIntersection={setIntersectingToilets}
-              onSelection={() => undefined}
+              onSelection={keyboardSelectionHandler}
               center={center}
             />
 
-            {/* <AccessibilityList
+            <AccessibilityList
               toilets={intersectingToilets.map(
                 (toilet: { name: any }) => toilet.name
               )}
-            /> */}
+            />
 
-            {/* <VisuallyHidden>
+            <VisuallyHidden>
               <div
                 role="status"
                 aria-atomic="true"
@@ -268,7 +283,7 @@ const LooMap: React.FC<LooMapProps> = ({
               >
                 {announcement}
               </div>
-            </VisuallyHidden> */}
+            </VisuallyHidden>
           </>
         )}
       </MapContainer>

--- a/src/components/LooMap/Markers.tsx
+++ b/src/components/LooMap/Markers.tsx
@@ -61,9 +61,9 @@ const MarkerGroup: React.FC<{
   const router = useRouter();
   const [mapState, setMapState] = useMapState();
   const map = useMap();
-  const { filters } = mapState;
+  const { appliedFilters: filters } = mapState;
 
-  const { data, called } = useLoosByGeohashQuery({
+  const { data } = useLoosByGeohashQuery({
     variables: { geohash },
   });
 
@@ -127,7 +127,11 @@ const MarkerGroup: React.FC<{
 
   const [appliedFilterTypes, setAppliedFilterTypes] = useState<
     Array<FILTER_TYPE>
-  >([]);
+  >(
+    getAppliedFiltersAsFilterTypes(
+      config.filters.filter((filter) => filters[filter.id])
+    )
+  );
 
   useEffect(() => {
     const applied: Array<Filter> = config.filters.filter(

--- a/src/components/LooMap/Markers.tsx
+++ b/src/components/LooMap/Markers.tsx
@@ -49,8 +49,6 @@ const Markers: React.FC<{
   const surroundingTiles = neighbours.flatMap((n) => ngeohash.neighbors(n));
   const neighbourSet = new Set([...surroundingTiles]);
 
-  const [mapState] = useMapState();
-
   useEffect(() => {
     setLoadedToilets(neighbourSet);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/LooMap/Markers.tsx
+++ b/src/components/LooMap/Markers.tsx
@@ -1,11 +1,4 @@
-import {
-  Dispatch,
-  SetStateAction,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import ToiletMarkerIcon from './ToiletMarkerIcon';
 import * as L from 'leaflet';
@@ -13,12 +6,11 @@ import 'leaflet.markercluster';
 import 'leaflet.markercluster/dist/MarkerCluster.css';
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 import { useMap } from 'react-leaflet';
-import { Loo, useLoosByGeohashQuery } from '../../api-client/graphql';
+import { useLoosByGeohashQuery } from '../../api-client/graphql';
 import config, { Filter } from '../../config';
 import { useMapState } from '../MapState';
 import { FILTER_TYPE, getAppliedFiltersAsFilterTypes } from '../../lib/filter';
 import {
-  CompressedLooObject,
   filterCompressedLooByAppliedFilters,
   parseCompressedLoo,
 } from '../../lib/loo';
@@ -105,15 +97,18 @@ const MarkerGroup: React.FC<{
 
   const initialiseMarker = useCallback(
     (toilet) => {
-      return L.marker(new L.LatLng(toilet.location.lat, toilet.location.lng), {
-        zIndexOffset: 0,
-        icon: new ToiletMarkerIcon({
-          toiletId: toilet.id,
-          isHighlighted: toilet.id === mapState?.focus?.id,
-        }),
-        alt: 'Public Toilet',
-        keyboard: false,
-      })
+      const marker = L.marker(
+        new L.LatLng(toilet.location.lat, toilet.location.lng),
+        {
+          zIndexOffset: 0,
+          icon: new ToiletMarkerIcon({
+            toiletId: toilet.id,
+            isHighlighted: toilet.id === mapState?.focus?.id,
+          }),
+          alt: 'Public Toilet',
+          keyboard: false,
+        }
+      )
         .on('click', () => {
           router.push(`/loos/${toilet.id}`);
         })
@@ -122,6 +117,10 @@ const MarkerGroup: React.FC<{
             router.push(`/loos/${toilet.id}`);
           }
         });
+
+      marker.getElement()?.setAttribute('role', 'link');
+      marker.getElement()?.setAttribute('aria-label', 'Public Toilet');
+      return marker;
     },
     [mapState?.focus?.id, router]
   );

--- a/src/components/MapState.tsx
+++ b/src/components/MapState.tsx
@@ -2,6 +2,7 @@ import { Map } from 'leaflet';
 import React, { Dispatch, useEffect } from 'react';
 import { Loo } from '../api-client/graphql';
 import config, { Filter, FILTERS_KEY } from '../config';
+import { CompressedLooObject } from '../lib/loo';
 import { UseLocateMapControl } from './LooMap/useLocateMapControl';
 
 const MapStateContext =
@@ -25,6 +26,7 @@ interface MapState {
   focus?: Loo;
   map?: Map;
   locationServices?: UseLocateMapControl;
+  loadedGroups?: Record<string, CompressedLooObject>;
 }
 
 const reducer = (state: MapState, newState: MapState) => {
@@ -46,6 +48,7 @@ export const MapStateProvider = ({ children, loos = [] }) => {
     zoom: 16,
     filters: initialFilterState,
     searchLocation: undefined,
+    loadedGroups: {},
   });
 
   // keep local storage and state in sync

--- a/src/components/MapState.tsx
+++ b/src/components/MapState.tsx
@@ -22,7 +22,7 @@ interface MapState {
     lng: number;
   };
   zoom?: number;
-  filters?: Filter[];
+  appliedFilters?: Filter[];
   focus?: Loo;
   map?: Map;
   locationServices?: UseLocateMapControl;
@@ -46,14 +46,17 @@ export const MapStateProvider = ({ children, loos = [] }) => {
   const [state, setState] = React.useReducer(reducer, {
     center: config.fallbackLocation,
     zoom: 16,
-    filters: initialFilterState,
+    appliedFilters: initialFilterState,
     searchLocation: undefined,
     loadedGroups: {},
   });
 
   // keep local storage and state in sync
   useEffect(() => {
-    window.localStorage.setItem(FILTERS_KEY, JSON.stringify(state.filters));
+    window.localStorage.setItem(
+      FILTERS_KEY,
+      JSON.stringify(state.appliedFilters)
+    );
   }, [state]);
 
   return (

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -105,7 +105,7 @@ const Sidebar = () => {
               <Box
                 as="button"
                 itemType="button"
-                onClick={() => setMapState({ ...mapState, filters: {} })}
+                onClick={() => setMapState({ ...mapState, appliedFilters: {} })}
                 border={0}
                 borderBottom={2}
                 borderStyle="solid"
@@ -177,7 +177,9 @@ const Sidebar = () => {
                   <Box
                     as="button"
                     type="button"
-                    onClick={() => setMapState({ ...mapState, filters: {} })}
+                    onClick={() =>
+                      setMapState({ ...mapState, appliedFilters: {} })
+                    }
                     border={0}
                     borderBottom={2}
                     borderStyle="solid"

--- a/src/lib/loo.ts
+++ b/src/lib/loo.ts
@@ -10,7 +10,7 @@ export type LooProperties = Omit<Loo, '__typename'> & {
 
 type CompressedLooString = `${string}|${string}|${number}`;
 
-type CompressedLooObject = {
+export type CompressedLooObject = {
   id: string;
   location: {
     lng: number;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -44,6 +44,7 @@ const HomePage = () => {
           center={mapState.center}
           zoom={mapState.zoom}
           controlsOffset={0}
+          withAccessibilityOverlays={true}
         />
       </Box>
     </>


### PR DESCRIPTION
## What has changed?

Fixes @falconx's accessibility overlay so that it works correctly with the new toilet clustering & geohash loading infrastructure.

I don't 100% like how I've gotten this to work but now we're nearing (fingers crossed) the last few big parts of the nextjs migration the next big thing after launching will be to tidy up stuff like my half-baked implementation here.

deployment: https://gbptm-next-3k5ig1cyq-neontribe.vercel.app/

Used a slightly awkward way of recording which toilets have been loaded in already for use in the accessibility list.. essentially populating a `loadedGroups` object in the map state as chunks are loaded in with compressed data (id, lat/lng, filter). In future we could probably just tap into the apollo cache, or remove chunks as they are loaded in/ out of the map instead of letting this store grow and grow. Or something even better!

Aside that, we then know which toilets are loaded using the `loadedGroups` object. Then we can re-enable the `AccessibilityIntersection` component which cuts the `loadedGroups` down into 6 loos as before.

Following this the toilet names are fetched using a new GQL query: `useLooNamesByIds`.. the query accepts the 6 toilet IDs and gives us 6 names (hopefully) in return. This happens in `AccessibilityList` and is necessary because toilet names aren't available to us anymore due to our efforts to decrease the size of the payload sent to users.

** Side thought:** One possible optimisation here would be to have an option to load names/extra metadata selectively for some geohash chunks at source in `Markers.tsx`.. then we could load extra metadata exclusively for the chunk in the middle of the screen for example. I'm imagining something like:

```
  const { data } = useLoosByGeohashQuery({
    variables: { geohash, extraFields: "name, creationDate" },
  });
```

Where `extraFields` is optional extra stuff you'd like chucked over in our compressed loo format. Having the name fetch as a separate request  does work for now though!

I've tested it locally with VoiceOver on my MacBook.. it seems to work well. Although @falconx  you might like to check yourself!

Some screenshots:
![Screenshot 2022-02-13 at 01 43 41](https://user-images.githubusercontent.com/1771189/153735088-c3ac6465-74b2-49fc-b95c-4e50f06b05a0.png)
![Screenshot 2022-02-13 at 01 44 15](https://user-images.githubusercontent.com/1771189/153735090-0d225859-3e2b-4468-881e-f561630a0390.png)



Resolves #1273 
