### PR TITLE
Upgrade gql to 15.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "downshift": "6.1.7",
     "focus-visible": "5.2.0",
     "framer-motion": "6.2.8",
-    "graphql": "15.6.1",
+    "graphql": "15.8.0",
     "graphql-iso-date": "3.6.1",
     "graphql-voyager": "1.0.0-rc.31",
     "hasha": "5.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5408,10 +5408,10 @@ graphql-ws@^5.4.1:
   resolved "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.4.1.tgz"
   integrity sha512-maBduPneZOFYb3otLgc9/U+fU3f9MVXLKg6lVVLqA9BDQQ6YR7YhQO21Rf9+44IRBi4l8m35lynFMFQTzN3eAQ==
 
-graphql@15.6.1:
-  version "15.6.1"
-  resolved "https://registry.npmjs.org/graphql/-/graphql-15.6.1.tgz"
-  integrity sha512-3i5lu0z6dRvJ48QP9kFxBkJ7h4Kso7PS8eahyTFz5Jm6CvQfLtNIE8LX9N6JLnXTuwR+sIYnXzaWp6anOg0QQw==
+graphql@15.8.0:
+  version "15.8.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
+  integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
 
 hard-rejection@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Couldn't ugprade `graphql` to latest v 16 because `graphql-codegen-apollo-next-ssr` doesn't support it yet. We could look into why and open a PR there if we need a v16 feature (not really sure what this release adds though) but for now should be fine

