### PR TITLE
Fix apollo client schema

### DIFF
--- a/src/api-client/schema.ts
+++ b/src/api-client/schema.ts
@@ -1,0 +1,27 @@
+const schema = (authDirective, redactedDirective) => {
+  const typeDefs = require('../api/typeDefs');
+  const resolvers = require('../api/resolvers');
+
+  const { makeExecutableSchema } = require('@graphql-tools/schema');
+
+  // Build our executable schema and apply our custom directives
+  const { redactedDirectiveTypeDefs, redactedDirectiveTransformer } =
+    redactedDirective('redact');
+  const { authDirectiveTypeDefs, authDirectiveTransformer } =
+    authDirective('auth');
+
+  return authDirectiveTransformer(
+    redactedDirectiveTransformer(
+      makeExecutableSchema({
+        typeDefs: [
+          redactedDirectiveTypeDefs,
+          authDirectiveTypeDefs,
+          typeDefs.default,
+        ],
+        resolvers,
+      })
+    )
+  );
+};
+
+export default schema;

--- a/src/api-client/withApollo.tsx
+++ b/src/api-client/withApollo.tsx
@@ -1,6 +1,4 @@
 import { NextPage } from 'next';
-import merge from 'deepmerge';
-import isEqual from 'lodash/isEqual';
 
 import {
   ApolloClient,
@@ -11,6 +9,8 @@ import {
 } from '@apollo/client';
 
 import { createPersistedQueryLink } from '@apollo/client/link/persisted-queries';
+import redactedDirective from '../api/directives/redactedDirective';
+import authDirective from '../api/directives/authDirective';
 import { sha256 } from 'crypto-hash';
 
 let apolloClient: ApolloClient<NormalizedCacheObject> | undefined;
@@ -19,8 +19,10 @@ function createApolloClient() {
   let terminatingLink;
   if (typeof window === 'undefined') {
     const { SchemaLink } = require('@apollo/client/link/schema');
-    const { schema } = require('../pages/api');
-    terminatingLink = new SchemaLink({ schema });
+    const { default: schema } = require('./schema');
+    terminatingLink = new SchemaLink({
+      schema: schema(authDirective, redactedDirective),
+    });
   } else {
     terminatingLink = createHttpLink({
       uri: '/api',

--- a/src/api/resolvers.ts
+++ b/src/api/resolvers.ts
@@ -1,6 +1,5 @@
 import { stringifyAndCompressLoos } from '../lib/loo';
 import ngeohash from 'ngeohash';
-import { async } from 'hasha';
 
 const { Loo, Report, Area, MapGeo } = require('./db');
 const { GraphQLDateTime } = require('graphql-iso-date');


### PR DESCRIPTION
Fixes the import of the apollo client schema which started returning a promise after the recent package upgrade in #340 
Splits out the executable schema init into its own file that can be supplied with the directives that turned into promises after the upgrade