### PR TITLE
 fix: OpenStreetMap attribution required by license

### DIFF
--- a/src/components/LooMap/LooMap.js
+++ b/src/components/LooMap/LooMap.js
@@ -238,6 +238,7 @@ const LooMap = ({
         `}
       >
         <TileLayer
+          attribution="&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors"
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           minZoom={minZoom}
           maxZoom={maxZoom}


### PR DESCRIPTION
Quote from https://www.openstreetmap.org/copyright
> You are free to copy, distribute, transmit and adapt our data, as long as you credit OpenStreetMap and its contributors.

This attribution code was adapted from https://react-leaflet.js.org

**Preview**
![image](https://user-images.githubusercontent.com/976274/166144414-18b63c1c-5b82-4696-928b-24dccd480208.png)
