### PR TITLE
Count applied filters, align cta buttons on mobile

### DIFF
--- a/cypress/integration/desktop/edit.spec.ts
+++ b/cypress/integration/desktop/edit.spec.ts
@@ -1,7 +1,7 @@
 import faker from '@faker-js/faker';
 import _ from 'lodash';
 describe('Edit page tests', () => {
-  context('Mobile', () => {
+  context('Desktop', () => {
     beforeEach(() => {
       cy.viewport('macbook-16');
     });
@@ -153,6 +153,7 @@ describe('Edit page tests', () => {
       cy.visit('loos/e0ba1aeea36ecf58d5ae6dd2/edit').wait(500);
       cy.findByPlaceholderText('Search location…').type('birmingham');
       cy.get('#search-results-item-0').click();
+      cy.wait(500);
       cy.findByText('Update the toilet').click();
 
       cy.contains('Thank you, details updated!');

--- a/cypress/integration/desktop/edit.spec.ts
+++ b/cypress/integration/desktop/edit.spec.ts
@@ -149,7 +149,40 @@ describe('Edit page tests', () => {
       cy.contains('I ran out of loo roll! Otherwise good.');
     });
 
-    it('should update the location of the toilet when the locator map is dragged', () => {
+    it('should update the location of the toilet to where the map is dragged', () => {
+      cy.visit('loos/e0ba1aeea36ecf58d5ae6dd2/edit').wait(500);
+      cy.get('#gbptm-map')
+        .trigger('mousedown', { which: 1, force: true })
+        .trigger('mousemove', { which: 1, x: 1000, y: 0 })
+        .trigger('mouseup', { force: true })
+        .wait(100)
+        .trigger('mousedown', { which: 1, force: true })
+        .trigger('mousemove', { which: 1, x: 1000, y: 0 })
+        .trigger('mouseup', { force: true })
+        .wait(100)
+        .trigger('mousedown', { which: 1, force: true })
+        .trigger('mousemove', { which: 1, x: 1000, y: 0 })
+        .trigger('mouseup', { force: true })
+        .wait(100)
+        .trigger('mousedown', { which: 1, force: true })
+        .trigger('mousemove', { which: 1, x: 1000, y: 0 })
+        .trigger('mouseup', { force: true })
+        .wait(100)
+        .trigger('mousedown', { which: 1, force: true })
+        .trigger('mousemove', { which: 1, x: 1000, y: 0 })
+        .trigger('mouseup', { force: true });
+      cy.findByText('Update the toilet').click();
+
+      cy.contains('Thank you, details updated!');
+
+      cy.visit('/');
+      cy.findByPlaceholderText('Search location…').type('ashford common');
+      cy.get('#search-results-item-0').click();
+
+      cy.get('[data-toiletid=e0ba1aeea36ecf58d5ae6dd2]').should('exist');
+    });
+
+    it('should update the location of the toilet through a location search', () => {
       cy.visit('loos/e0ba1aeea36ecf58d5ae6dd2/edit').wait(500);
       cy.findByPlaceholderText('Search location…').type('birmingham');
       cy.get('#search-results-item-0').click();
@@ -162,17 +195,6 @@ describe('Edit page tests', () => {
       cy.findByPlaceholderText('Search location…').type('birmingham');
       cy.get('#search-results-item-0').click();
 
-      cy.get('#gbptm-map')
-        .trigger('wheel', {
-          deltaY: 66.666666,
-          wheelDelta: 120,
-          wheelDeltaX: 0,
-          wheelDeltaY: -1500,
-          bubbles: true,
-        })
-        .wait(500);
-
-      // TODO: Once we have implemented invalidation of map chunks on update, check that it is updated without having to zoom out to an unloaded geohash
       cy.get('[data-toiletid=e0ba1aeea36ecf58d5ae6dd2]').should('exist');
     });
   });

--- a/cypress/integration/desktop/index.spec.ts
+++ b/cypress/integration/desktop/index.spec.ts
@@ -16,9 +16,7 @@ describe('Home page tests', () => {
     });
 
     it('should let you search by location', () => {
-      cy.reload();
       cy.visit('/');
-
       cy.findByPlaceholderText('Search location…').type('Hammersmith');
       cy.get('#search-results-item-0').click();
       cy.get('[data-toiletid=891ecdfaf8d8e4ffc087f7ce]').should('exist');

--- a/cypress/integration/mobile/edit.spec.ts
+++ b/cypress/integration/mobile/edit.spec.ts
@@ -149,7 +149,44 @@ describe('Edit page tests', () => {
       cy.contains('I ran out of loo roll! Otherwise good.');
     });
 
-    it('should update the location of the toilet when the locator map is dragged', () => {
+    it('should update the location of the toilet to where the map is dragged', () => {
+      cy.visit('loos/ca6249ebcd1490e2aaccc5be/edit').wait(500);
+
+      // touchstart, touchmove etc are not supported in Firefox
+      if (Cypress.isBrowser('firefox')) {
+        cy.get('#gbptm-map')
+          .trigger('mousedown', { which: 1, force: true })
+          .trigger('mousemove', 1000, -1800, { which: 1, force: true })
+          .trigger('mouseup', { force: true })
+          .wait(100)
+          .trigger('mousedown', { which: 1, force: true })
+          .trigger('mousemove', -1500, 1100, { which: 1, force: true })
+          .trigger('mouseup', { force: true })
+          .wait(500);
+      } else {
+        cy.get('#gbptm-map')
+          .trigger('touchstart', { which: 1, force: true })
+          .trigger('touchmove', 1000, -1800, { which: 1, force: true })
+          .trigger('touchend', { force: true })
+          .wait(100)
+          .trigger('touchstart', { which: 1, force: true })
+          .trigger('touchmove', -1500, 1100, { which: 1, force: true })
+          .trigger('touchend', { force: true })
+          .wait(500);
+      }
+
+      cy.findByText('Update the toilet').click();
+
+      cy.contains('Thank you, details updated!');
+
+      cy.visit('/');
+      cy.findByPlaceholderText('Search location…').type('ditton park manor');
+      cy.get('#search-results-item-0').click();
+
+      cy.get('[data-toiletid=ca6249ebcd1490e2aaccc5be]').should('exist');
+    });
+
+    it('should update the location of the toilet through a location search', () => {
       cy.visit('loos/ca6249ebcd1490e2aaccc5be/edit').wait(500);
       cy.findByPlaceholderText('Search location…').type('Norwich');
       cy.get('#search-results-item-0').click();
@@ -162,17 +199,6 @@ describe('Edit page tests', () => {
       cy.findByPlaceholderText('Search location…').type('Norwich');
       cy.get('#search-results-item-0').click();
 
-      cy.get('#gbptm-map')
-        .trigger('wheel', {
-          deltaY: 66.666666,
-          wheelDelta: 120,
-          wheelDeltaX: 0,
-          wheelDeltaY: -1500,
-          bubbles: true,
-        })
-        .wait(500);
-
-      // TODO: Once we have implemented invalidation of map chunks on update, check that it is updated without having to zoom out to an unloaded geohash
       cy.get('[data-toiletid=ca6249ebcd1490e2aaccc5be]').should('exist');
     });
   });

--- a/cypress/integration/mobile/index.spec.ts
+++ b/cypress/integration/mobile/index.spec.ts
@@ -68,8 +68,8 @@ describe('Home page tests', () => {
 
       cy.get('[data-toiletid=ddad1ed1b91d99ed2bf3bcdf]').should('exist');
       cy.get('[data-toiletid=cc4e5e9b83de8dd9ba87b3eb]').should('not.exist');
-      // touchstart, touchmove etc are not supported in Firefox
 
+      // touchstart, touchmove etc are not supported in Firefox
       if (Cypress.isBrowser('firefox')) {
         cy.get('#gbptm-map')
           .trigger('mousedown', { which: 1 })

--- a/src/components/EntryForm.tsx
+++ b/src/components/EntryForm.tsx
@@ -232,7 +232,6 @@ const EntryForm = ({ title, loo, children, ...props }) => {
   useEffect(
     function setMapMovedIfSearchHappened() {
       if (mapState.searchLocation) {
-        console.log(mapState.searchLocation);
         setMapMoved(true);
       }
     },

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -111,29 +111,29 @@ const Sidebar = () => {
           }
         />
 
-        <Box display="flex" justifyContent="center" mt={3}>
-          <Button
-            ref={filterToggleRef}
-            variant="secondary"
-            icon={<FontAwesomeIcon icon={faFilter} />}
-            aria-expanded={isFiltersExpanded}
-            onClick={() => setIsFiltersExpanded(!isFiltersExpanded)}
-          >
-            Filter Map
-          </Button>
+        <Box display="flex" flexWrap="wrap" justifyContent="center">
+          <Box display="flex" mt={3} mr={1}>
+            <Button
+              ref={filterToggleRef}
+              variant="secondary"
+              icon={<FontAwesomeIcon icon={faFilter} />}
+              aria-expanded={isFiltersExpanded}
+              onClick={() => setIsFiltersExpanded(!isFiltersExpanded)}
+            >
+              Filter Map
+            </Button>
+          </Box>
+          <Box display="flex" mt={3}>
+            <Button
+              type="button"
+              variant="primary"
+              onClick={() => mapState?.locationServices?.startLocate()}
+              aria-label="Find a toilet near me"
+            >
+              Find a toilet near me
+            </Button>
+          </Box>
         </Box>
-
-        <Box display="flex" justifyContent="center" mt={3}>
-          <Button
-            type="button"
-            variant="primary"
-            onClick={() => mapState?.locationServices?.startLocate()}
-            aria-label="Find a toilet near me"
-          >
-            Find a toilet near me
-          </Button>
-        </Box>
-
         <Drawer visible={isFiltersExpanded} animateFrom="left">
           <Box display="flex" justifyContent="space-between" mb={4}>
             <Box display="flex" alignItems="flex-end">

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useMemo } from 'react';
+import { useState, useRef, useMemo, useEffect } from 'react';
 import styled from '@emotion/styled';
 import isPropValid from '@emotion/is-prop-valid';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -20,6 +20,7 @@ import Filters from '../Filters';
 import Button from '../Button';
 import Drawer from '../Drawer';
 import { useMapState } from '../MapState';
+import config from '../../config';
 
 interface Props {
   isExpanded?: boolean;
@@ -80,6 +81,23 @@ const Sidebar = () => {
     [isFilterExpanded, isFiltersExpanded, mapState, setMapState]
   );
 
+  const [appliedFilterCount, setAppliedFilterCount] = useState(0);
+
+  useEffect(
+    function setTheAmountOfAppliedFilters() {
+      setAppliedFilterCount(
+        config.filters
+          .map(({ id }) => mapState.appliedFilters?.[id] === true)
+          .reduce((v, c) => +c + v, 0)
+      );
+    },
+    [mapState.appliedFilters]
+  );
+
+  const appliedFilterCountRendered = useMemo(() => {
+    return appliedFilterCount > 0 && <b>({appliedFilterCount})</b>;
+  }, [appliedFilterCount]);
+
   return (
     <section aria-labelledby="heading-search">
       <Media lessThan="md">
@@ -123,6 +141,7 @@ const Sidebar = () => {
               <Box as="h2" mx={2}>
                 <Text lineHeight={1}>
                   <b>Filter</b>
+                  {appliedFilterCountRendered}
                 </Text>
               </Box>
             </Box>
@@ -179,7 +198,9 @@ const Sidebar = () => {
 
           <Box as="section" my={4} aria-labelledby="heading-filters">
             <h2 id="heading-filters">
-              <VisuallyHidden>Filters</VisuallyHidden>
+              <VisuallyHidden>
+                Filters — {appliedFilterCount} filters are applied.
+              </VisuallyHidden>
             </h2>
 
             <Box display="flex" justifyContent="space-between">
@@ -194,7 +215,8 @@ const Sidebar = () => {
                 <Icon icon={faFilter} fixedWidth size="lg" />
                 <Box mx={2}>
                   <Text lineHeight={1}>
-                    <b>Filter</b>
+                    <b>Filter </b>
+                    {appliedFilterCountRendered}
                   </Text>
                 </Box>
                 <Arrow isExpanded={isFilterExpanded} />

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -13,9 +13,9 @@ const App = (props) => {
     sharedStatePaths.indexOf(router.pathname) > -1 ? 'shared' : router.asPath;
 
   return (
-    <Providers>
+    <Providers key={key}>
       <UserProvider>
-        <Main {...props} key={key} />
+        <Main {...props} />
       </UserProvider>
     </Providers>
   );


### PR DESCRIPTION
<details>
  <summary>Adds a count so that there is a visual indication of how many filters are applied:</summary>
  
 
![Screenshot 2022-05-29 at 00 14 54](https://user-images.githubusercontent.com/1771189/170845610-2330a609-f6bc-424c-8469-69ebb4cb8a14.png)
![Screenshot 2022-05-29 at 00 14 56](https://user-images.githubusercontent.com/1771189/170845613-7a260a47-5fe9-4890-b6dd-66522204f0bf.png)

</details>

<details>
  <summary>Stack buttons only on smaller viewports:</summary>
  

![Screenshot 2022-05-29 at 01 08 24](https://user-images.githubusercontent.com/1771189/170846650-b806544a-c0fb-44e6-87ed-53a180c0ec48.png)
![Screenshot 2022-05-29 at 01 08 46](https://user-images.githubusercontent.com/1771189/170846652-f5100828-e11a-4a21-8c1d-62f26e93602f.png)
</details>

Fixes how the map state is shared so that it is cleared when visiting the edit/add pages and kept on the root and when navigating between loos




