### PR TITLE
Migration | Just load the explorer

### DIFF
--- a/src/explorer/Home/index.js
+++ b/src/explorer/Home/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link as InternalLink, useRouteMatch } from 'react-router-dom';
+import { Link as InternalLink } from 'react-router-dom';
 import Paper from '@material-ui/core/Paper';
 import ExternalLink from '@material-ui/core/Link';
 import Typography from '@material-ui/core/Typography';
@@ -23,7 +23,6 @@ const SubTypography = withStyles({
 })(Typography);
 
 export default () => {
-  const match = useRouteMatch();
   return (
     <div className={styles.main}>
       <div className={styles.intro}>
@@ -66,10 +65,7 @@ export default () => {
             <HeadingTypography variant="h5">Stats</HeadingTypography>
             <SubTypography variant="body1">
               You can view a selection of high level statistics{' '}
-              <InternalLink
-                className={styles.internalLink}
-                to={`${match.path}statistics`}
-              >
+              <InternalLink className={styles.internalLink} to={`statistics`}>
                 here
               </InternalLink>
             </SubTypography>
@@ -80,10 +76,7 @@ export default () => {
             <HeadingTypography variant="h5">Search</HeadingTypography>
             <SubTypography variant="body1">
               You can search for toilet data using keyword searches{' '}
-              <InternalLink
-                className={styles.internalLink}
-                to={`${match.path}search`}
-              >
+              <InternalLink className={styles.internalLink} to={`search`}>
                 here
               </InternalLink>
             </SubTypography>
@@ -105,10 +98,7 @@ export default () => {
               <ExternalLink href={'https://graphql.org/'}>GraphQL</ExternalLink>
               . The endpoint is served at `https://www.toiletmap.org.uk/api`.You
               can{' '}
-              <InternalLink
-                className={styles.internalLink}
-                to={`${match.path}voyager`}
-              >
+              <InternalLink className={styles.internalLink} to={`voyager`}>
                 visualise the schema
               </InternalLink>
               , or{' '}

--- a/src/explorer/Layout.js
+++ b/src/explorer/Layout.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link, useRouteMatch, useHistory } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
@@ -39,14 +39,9 @@ const CentredListItem = withStyles({
 })(ListItem);
 
 function SidebarItem(props) {
-  const match = useRouteMatch();
-
   return (
     <CentredListItem button>
-      <Link
-        to={`${match.path}/${props.pathName}`}
-        style={{ textDecoration: 'none' }}
-      >
+      <Link to={`/${props.pathName}`} style={{ textDecoration: 'none' }}>
         <div className={styles.centredLink}>
           <ListItemIcon>{props.icon}</ListItemIcon>
           <NewListItemText primary={props.name} />

--- a/src/explorer/index.js
+++ b/src/explorer/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Route, useRouteMatch } from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
 
 import Layout from './Layout';
 import Home from './Home';
@@ -11,12 +11,10 @@ import Voyager from './Voyager';
 import Map from './Map';
 
 export default function Explorer() {
-  let match = useRouteMatch();
-
   return (
     <Layout>
       <Switch>
-        <Route exact path={`${match.path}/`}>
+        <Route exact path={`/`}>
           <Home />
         </Route>
         <Route exact path={`/loos/:id`}>

--- a/src/explorer/index.js
+++ b/src/explorer/index.js
@@ -19,22 +19,22 @@ export default function Explorer() {
         <Route exact path={`${match.path}/`}>
           <Home />
         </Route>
-        <Route path={`${match.path}/loos/:id`}>
+        <Route exact path={`/loos/:id`}>
           <Loo />
         </Route>
-        <Route path={`${match.path}/statistics`}>
+        <Route exact path={`/statistics`}>
           <HeadlineStats />
         </Route>
-        <Route path={`${match.path}/areas`}>
+        <Route exact path={`/areas`}>
           <Areas />
         </Route>
-        <Route path={`${match.path}/search`}>
+        <Route exact path={`/search`}>
           <Search />
         </Route>
-        <Route path={`${match.path}/voyager`}>
+        <Route exact path={`/voyager`}>
           <Voyager />
         </Route>
-        <Route exact path={`${match.path}/map`}>
+        <Route exact path={`/map`}>
           <Map />
         </Route>
       </Switch>

--- a/src/graphql/fetcher.js
+++ b/src/graphql/fetcher.js
@@ -3,7 +3,9 @@ import { GraphQLClient } from 'graphql-request';
 
 import { isAuthenticated, getAccessToken } from '../Auth';
 
-const API_ENDPOINT = '/api';
+const API_ENDPOINT = process.env.PUBLIC_URL
+  ? process.env.PUBLIC_URL + '/api'
+  : '/api';
 
 const fetcher = (query, variables) => {
   const graphQLClient = new GraphQLClient(API_ENDPOINT);

--- a/src/index.js
+++ b/src/index.js
@@ -3,46 +3,25 @@ import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
 import 'resize-observer-polyfill';
 
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom';
-import { Router, Route, Switch, Redirect } from 'react-router-dom';
+import { Router, Switch } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
 import { SWRConfig } from 'swr';
 
-import ProtectedRoute from './components/ProtectedRoute';
-import AuthCallback from './pages/AuthCallback';
-import HomePage from './pages/HomePage';
-import AboutPage from './pages/AboutPage';
-import ContactPage from './pages/ContactPage';
-import ContributePage from './pages/ContributePage';
-import MapPage from './pages/MapPage';
-import CookiesPage from './pages/CookiesPage';
-import PrivacyPage from './pages/PrivacyPage';
-import NotFound from './pages/404';
 import PageLoading from './components/PageLoading';
 
 import AuthProvider from './Auth';
 import fetcher from './graphql/fetcher';
 import { MapStateProvider } from './components/MapState';
 
+import Explorer from './explorer/index';
+
 if (process.env.REACT_APP_MOCKS) {
   require('./mocks');
 }
 
 const history = createBrowserHistory();
-
-const Explorer = lazy(() =>
-  import(/*webpackChunkName: 'explorer'*/ './explorer')
-);
-const AddPage = lazy(() =>
-  import(/*webpackChunkName: 'add'*/ './pages/AddPage')
-);
-const EditPage = lazy(() =>
-  import(/*webpackChunkName: 'edit'*/ './pages/EditPage')
-);
-const RemovePage = lazy(() =>
-  import(/*webpackChunkName: 'remove'*/ './pages/RemovePage')
-);
 
 ReactDOM.render(
   <AuthProvider>
@@ -55,37 +34,7 @@ ReactDOM.render(
         <Router history={history}>
           <Suspense fallback={<PageLoading />}>
             <Switch>
-              <Route exact path="/" component={HomePage} />
-              <ProtectedRoute path="/loos/add" component={AddPage} />
-              <Route path="/loos/:id" exact component={HomePage} />
-              <Route exact path="/about" component={AboutPage} />
-              <Route exact path="/cookies" component={CookiesPage} />
-              <Route exact path="/privacy" component={PrivacyPage} />
-              <Route exact path="/contact" component={ContactPage} />
-              <Route
-                path="/contribute"
-                render={(props) => <ContributePage {...props} />}
-              />
-              <Route
-                path="/login"
-                render={() => <Redirect to="/contribute" />}
-              />
-              <Route
-                path="/map/:lng/:lat"
-                render={(props) => <MapPage {...props} />}
-              />
-              <Route
-                exact
-                path="/callback"
-                render={(props) => <AuthCallback {...props} />}
-              />
-              <Route
-                path="/explorer"
-                render={(props) => <Explorer {...props} />}
-              />
-              <ProtectedRoute path="/loos/:id/edit" component={EditPage} />
-              <ProtectedRoute path="/loos/:id/remove" component={RemovePage} />
-              <Route component={NotFound} />
+              <Explorer />
             </Switch>
           </Suspense>
         </Router>


### PR DESCRIPTION
## What does this change?

We create a few changes to the CRA version of the map so it only serves the toilet map explorer. We can then deploy it to a new Vercel app that will host it here: https://explorer.toiletmap.org.uk ; separate from the new version .

This will allow us to release `next` and keep the explorer until we find a more permanent solution.