### PR TITLE
Migration | Rewrite Explorer

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -21,6 +21,10 @@ module.exports = {
         source: '/map/:lng/:lat',
         destination: '/map',
       },
+      {
+        source: '/explorer',
+        destination: 'https://explorer.toiletmap.org.uk/',
+      },
     ];
   },
   webpack: (config, {}) => {


### PR DESCRIPTION
## What does this change?

This adds a rewrite to the next config so that we can still direct people to the explorer app, which will be hosted separately for now here: https://explorer.toiletmap.org.uk

