### PR TITLE
Transpile react-leaflet and markercluster 

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -64,7 +64,13 @@ const sentryWebpackPluginOptions = {
   dryRun: process.env.VERCEL_ENV !== 'production',
 };
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const withTM = require('next-transpile-modules')(['react-leaflet']);
+
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
 // eslint-disable-next-line functional/immutable-data
-module.exports = withSentryConfig(moduleExports, sentryWebpackPluginOptions);
+module.exports = withSentryConfig(
+  withTM(moduleExports),
+  sentryWebpackPluginOptions
+);

--- a/next.config.js
+++ b/next.config.js
@@ -65,7 +65,11 @@ const sentryWebpackPluginOptions = {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const withTM = require('next-transpile-modules')(['react-leaflet']);
+const withTM = require('next-transpile-modules')([
+  '@react-leaflet/core',
+  'react-leaflet',
+  'leaflet.markercluster',
+]);
 
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "mongoose-paginate": "^5.0.3",
     "next": "^12.1.6",
     "next-plausible": "^3.2.0",
+    "next-transpile-modules": "^9.0.0",
     "ngeohash": "^0.6.3",
     "nodemon": "^2.0.16",
     "prop-types": "^15.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12868,6 +12868,14 @@ next-plausible@^3.2.0:
   resolved "https://registry.yarnpkg.com/next-plausible/-/next-plausible-3.2.0.tgz#d801346253e0c1cf64a02b9fc3a42050455cbc47"
   integrity sha512-OlYcLXBG3kKd/fKMpm8SZ5IkUKSFm1/8t7cv6e5bewIqlpdZpdWuSrjbdJpbmutb2KPLXHzilKp09zmDGjy9KQ==
 
+next-transpile-modules@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-9.0.0.tgz#133b1742af082e61cc76b02a0f12ffd40ce2bf90"
+  integrity sha512-VCNFOazIAnXn1hvgYYSTYMnoWgKgwlYh4lm1pKbSfiB3kj5ZYLcKVhfh3jkPOg1cnd9DP+pte9yCUocdPEUBTQ==
+  dependencies:
+    enhanced-resolve "^5.7.0"
+    escalade "^3.1.1"
+
 next@^12.1.6:
   version "12.1.6"
   resolved "https://registry.yarnpkg.com/next/-/next-12.1.6.tgz#eb205e64af1998651f96f9df44556d47d8bbc533"


### PR DESCRIPTION
## What does this change?

These modules were including the null coalesce operator in the build, meaning that the app crashed at runtime on older browsers. 

This change ensures that these modules are transpiled as part of our build step using `next-transpile-modules` https://github.com/martpie/next-transpile-modules

Tested in Chrome 72 and the website now renders the map instead of erroring at runtime