### PR TITLE
Sentry sample rate modification

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -11,7 +11,7 @@ Sentry.init({
     SENTRY_DSN ||
     'https://6935d02f879c4536aecfe8fa07ae1d3a@o1270901.ingest.sentry.io/6462188',
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 0.01,
+  tracesSampleRate: 0.25,
   environment: process.env.NEXT_PUBLIC_VERCEL_ENV || 'development',
   enabled: process.env.NEXT_PUBLIC_VERCEL_ENV === 'production',
   // ...


### PR DESCRIPTION
## What does this change?
Sentry very kindly upgraded us to a sponsored plan, meaning that we have a 5 million(!) cap on the number of errors we can record. 

Given this is a very high number compared to the traffic we get, let's sample more!