### PR TITLE
fix: border on controls, and add bounded cache for persisted query vuln

### DIFF
--- a/src/components/LooMap/LooMap.tsx
+++ b/src/components/LooMap/LooMap.tsx
@@ -251,7 +251,7 @@ const LooMap: React.FC<LooMapProps> = ({
           }
 
           .leaflet-bar {
-            border: none;
+            border: none !important; // override leaflet default border
             box-shadow: none;
           }
 

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -12,10 +12,12 @@ const App = (props) => {
   const sharedStatePaths = ['/', '/loos/[id]'];
   const key =
     sharedStatePaths.indexOf(router.pathname) > -1 ? 'shared' : router.asPath;
+
   const renderedMap = useMemo(
     () => (key === 'shared' ? <LooMap /> : undefined),
     [key]
   );
+
   return (
     <Providers key={key}>
       <UserProvider>

--- a/src/pages/api/index.page.ts
+++ b/src/pages/api/index.page.ts
@@ -33,6 +33,7 @@ const finalSchema = schema(authDirective, redactedDirective);
 
 export const server = new ApolloServer({
   schema: finalSchema,
+  cache: 'bounded',
   context: async ({ req, res }) => {
     let user = null;
     try {


### PR DESCRIPTION
## What does this change?

A border shadow existed around the controls on the map:

<img width="89" alt="Screenshot 2022-07-04 at 23 01 41" src="https://user-images.githubusercontent.com/1771189/177220580-fff07342-6973-4c03-a99a-ab24ad54b378.png">

This PR removes it and also applies a "bounded" cache to the apollo server to protect us against a potential DOS attack: https://www.apollographql.com/docs/apollo-server/performance/cache-backends/ — this is strongly recommended in the linked documentation
