### PR TITLE
Fix SSR error

### DIFF
--- a/src/components/ToiletDetailsPanel.tsx
+++ b/src/components/ToiletDetailsPanel.tsx
@@ -203,20 +203,24 @@ const ToiletDetailsPanel = ({
     </Link>
   );
 
-  const crossIconFragment = (
-    <Icon icon={faTimes} color="tertiary" title="unavailable" />
-  );
-  const questionIconFragment = (
-    <Icon icon={faQuestion} color="tertiary" title="unknown" />
-  );
-  const checkIconFragment = <Icon icon={faCheck} title="available" />;
-
   const getFeatureValueIcon = (value) => {
     if (value === null) {
-      return questionIconFragment;
+      return (
+        <Box title="Unknown">
+          <Icon icon={faQuestion} color="tertiary" />
+        </Box>
+      );
     }
 
-    return value ? checkIconFragment : crossIconFragment;
+    return value ? (
+      <Box title="Available">
+        <Icon icon={faCheck} />
+      </Box>
+    ) : (
+      <Box title="Unavailable">
+        <Icon icon={faTimes} color="tertiary" />
+      </Box>
+    );
   };
 
   const features = [

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -2,7 +2,10 @@ import React, { useMemo } from 'react';
 import Providers from '../components/Providers';
 import { UserProvider } from '@auth0/nextjs-auth0';
 import Main from '../components/Main';
+import { config } from '@fortawesome/fontawesome-svg-core';
 import '@fortawesome/fontawesome-svg-core/styles.css';
+// eslint-disable-next-line functional/immutable-data
+config.autoAddCss = false; // Tell Font Awesome to skip adding the CSS automatically since it's being imported above
 import { useRouter } from 'next/router';
 import LooMap from '../components/LooMap/LooMapLoader';
 


### PR DESCRIPTION
## What does this change?

When applying titles to the rendered font awesome icons, we were experiencing a non-matching id error between the client and the server. We work around this problem by setting the title on a parent element.

This will hopefully reduce some of the noise we get on our Sentry logs

A small change is also made here: https://github.com/neontribe/gbptm/pull/1372/files#diff-4eddf35da52afa00c787cc8b42c10e7c04def3ecf6a4f83686bbdad6135ca0d4R8 to follow the font awesome docs for when using the library with nextjs