### PR TITLE
Loading loo pages on iPhone

### DIFF
--- a/src/components/LooMap/LooMapLoader.tsx
+++ b/src/components/LooMap/LooMapLoader.tsx
@@ -1,4 +1,5 @@
 import dynamic from 'next/dynamic';
+import { useEffect, useState } from 'react';
 import { withApollo } from '../../api-client/withApollo';
 import { useMapState } from '../MapState';
 import PageLoading from '../PageLoading';
@@ -10,13 +11,19 @@ export const LooMapLoader = dynamic(() => import('./LooMap'), {
 
 const LooMap = () => {
   const [mapState] = useMapState();
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    setLoaded(true);
+  }, []);
   return (
-    <LooMapLoader
-      center={mapState.center}
-      zoom={mapState.zoom}
-      controlsOffset={20}
-      withAccessibilityOverlays={true}
-    />
+    loaded && (
+      <LooMapLoader
+        center={mapState.center}
+        zoom={mapState.zoom}
+        controlsOffset={20}
+        withAccessibilityOverlays={true}
+      />
+    )
   );
 };
 


### PR DESCRIPTION
## What does this change?

Only on iPhones loo pages were not loading with the loo marker in focus and the map centred on it. Instead, the page was loaded with the loo deail panel but centred on central London, our default starting location.

We solve this issue by ensuring that the loo map is rendered in time to pick up the props that the /loos/[id] page sets to determine the marker focus and map centre

## How was this tested?

Locally and on a staging instance
