### PR TITLE
chore: update sentry serverside sample rate to match client

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This documentation is oriented towards developers, if you'd like to learn more a
 
 [![Powered by Vercel](./public/powered-by-vercel.svg)](https://vercel.com/?utm_source=public-convenience-ltd&utm_campaign=oss)
 
+Logging is kindly sponsored by Sentry:
+
+[<img src="https://user-images.githubusercontent.com/1771189/178340599-94f9d130-dd82-4389-a4ac-69b9fb014d8a.svg" width="212" alt="Logging is kindly sponsored by Sentry">](https://sentry.io)
+
 ## Getting Started
 
 ### Prerequisites

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -11,7 +11,7 @@ Sentry.init({
     SENTRY_DSN ||
     'https://6935d02f879c4536aecfe8fa07ae1d3a@o1270901.ingest.sentry.io/6462188',
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 0.01,
+  tracesSampleRate: 0.25,
   environment: process.env.VERCEL_ENV || 'development',
   enabled: process.env.VERCEL_ENV === 'production',
   // ...


### PR DESCRIPTION
## What does this change?
We neglected to updated this to match the client side sample rate when we got bumped to a premier tier plan

Updates our Readme with logo to indicate suport from Sentry:
![sentry-wordmark-dark-400x119](https://user-images.githubusercontent.com/1771189/178340599-94f9d130-dd82-4389-a4ac-69b9fb014d8a.svg)

