### PR TITLE
fix: use the official cypress firefox container image

### DIFF
--- a/.github/workflows/cypress-e2e-firefox.yml
+++ b/.github/workflows/cypress-e2e-firefox.yml
@@ -4,6 +4,9 @@ jobs:
   cypress-e2e-firefox:
     name: Cypress E2E Firefox
     runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
+      options: --user 1001
     timeout-minutes: 15
     steps:
       - name: Checkout


### PR DESCRIPTION
## What does this change?
Firefox was breaking occasionally during our tests. This will hopefully ensure that the image we use remains stable