### PR TITLE
Add a minimum zoom to the main map

### DIFF
--- a/src/components/LooMap/LooMap.tsx
+++ b/src/components/LooMap/LooMap.tsx
@@ -32,7 +32,7 @@ const MapTracker = () => {
   return null;
 };
 
-interface LooMapProps {
+export interface LooMapProps {
   center: { lat: number; lng: number };
   zoom?: number;
   minZoom?: number;

--- a/src/components/LooMap/LooMapLoader.tsx
+++ b/src/components/LooMap/LooMapLoader.tsx
@@ -3,13 +3,14 @@ import { useEffect, useState } from 'react';
 import { withApollo } from '../../api-client/withApollo';
 import { useMapState } from '../MapState';
 import PageLoading from '../PageLoading';
+import { LooMapProps } from './LooMap';
 
 export const LooMapLoader = dynamic(() => import('./LooMap'), {
   loading: PageLoading,
   ssr: false,
 });
 
-const LooMap = () => {
+const LooMap = (props: LooMapProps) => {
   const [mapState] = useMapState();
   const [loaded, setLoaded] = useState(false);
   useEffect(() => {
@@ -22,6 +23,7 @@ const LooMap = () => {
         zoom={mapState.zoom}
         controlsOffset={20}
         withAccessibilityOverlays={true}
+        {...props}
       />
     )
   );

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -20,7 +20,7 @@ const App = (props) => {
     () =>
       key === 'shared' ? (
         <Suspense>
-          <LooMap />
+          <LooMap minZoom={5} />
         </Suspense>
       ) : undefined,
     [key]


### PR DESCRIPTION
## What does this change?
We prevent users from zooming out too far and displaying the map so that it wraps around which causes a noticeable slowdown. Users can still zoom out to an international level with this change, just not further.