### PR TITLE
Add another machine to Cypress action run

### DIFF
--- a/.github/workflows/cypress-e2e-chrome.yml
+++ b/.github/workflows/cypress-e2e-chrome.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         # run 4 copies of the current job in parallel
-        containers: [1, 2, 3, 4]
+        containers: [1, 2, 3, 4, 5]
     services:
       redis:
         image: redis

--- a/.github/workflows/cypress-e2e-firefox.yml
+++ b/.github/workflows/cypress-e2e-firefox.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         # run 4 copies of the current job in parallel
-        containers: [1, 2, 3, 4]
+        containers: [1, 2, 3, 4, 5]
     services:
       redis:
         image: redis


### PR DESCRIPTION
## What does this change?
According to the Cypress Dashboard, this will save us another 20 seconds-ish for each run
