### PR TITLE
Redis cache TTL increase

### DIFF
--- a/src/api/schema.graphql
+++ b/src/api/schema.graphql
@@ -208,7 +208,7 @@ type Query {
   "Retrieve a list of areas in existence, name and type only"
   areas: [AdminGeo!]!
   loosByGeohash(geohash: String!): [String!]!
-    @cacheControl(maxAge: 1800, scope: PUBLIC)
+    @cacheControl(maxAge: 21600, scope: PUBLIC)
   "Retrieve the explorer map TopoJSON data"
   mapAreas(areaType: String): TopoGeo
   "Retrieve a report by ID"

--- a/src/pages/api/index.page.ts
+++ b/src/pages/api/index.page.ts
@@ -97,7 +97,7 @@ export const server = createServer({
       enabled: (context) => !context?.user || !context?.revalidate,
       session: () => null,
       cache,
-      ttl: 60 * 1000 * 60, // cache tiles for 60 mins by default
+      ttl: 60 * 1000 * 60 * 6, // cache tiles for 6 hours
       buildResponseCacheKey: async (params) => {
         const geohash = params.variableValues?.geohash;
         // prefer the VERCEL_URL env variable so cache is unique for each staging deploy


### PR DESCRIPTION
## What does this change?
We increase the TTL (time to live) of our Redis geohash cache to 6 hours because editing/adding loo cache invalidation is working as expected.

This means in practice that we can make even fewer requests to Mongo for loo information during day-to-day usage of the website