### PR TITLE
Fix: ensure that buttons wrap correctly on collapsed loo details

### DIFF
--- a/src/design-system/components/ToiletDetailsPanel/ToiletDetailsPanel.css
+++ b/src/design-system/components/ToiletDetailsPanel/ToiletDetailsPanel.css
@@ -17,9 +17,9 @@
 
 .toilet-details-panel__heading {
     display: inline-flex;
+    flex-grow: 1;
     gap: var(--space-s);
     justify-content: space-between;
-    width: 100%;
 }
 
 .toilet-details-panel__container {
@@ -77,12 +77,26 @@
     align-items: flex-start;
 }
 
-.toilet-details-panel--collapsed .center {
+.toilet-details-panel__collapsed-title {
     align-items: center;
-    display: flex;    
-    flex-wrap: wrap;
+    display: flex;
     gap: var(--space-s);
-    justify-content: space-between;
+    flex-wrap: wrap-reverse;
+    margin-block-end: var(--space-m);
+}
+
+.toilet-details-panel__collapsed-title .button {
+    margin-inline-start: auto;
+}
+
+.toilet-details-panel__actions {
+    display: flex;
+    gap: var(--space-s);
+    flex-wrap: wrap;
+}
+
+.toilet-details-panel__actions .button {
+    width: min(100%, 250px);
 }
 
 .toilet-details-panel__back-to-top {

--- a/src/design-system/components/ToiletDetailsPanel/ToiletDetailsPanel.tsx
+++ b/src/design-system/components/ToiletDetailsPanel/ToiletDetailsPanel.tsx
@@ -324,14 +324,25 @@ const ToiletDetailsPanel: React.FC<ToiletDetailsPanelProps> = ({
       data-testid="toilet-details"
     >
       <Center text={false} gutter={true} article={false}>
-        <Stack>
+        <div className="toilet-details-panel__collapsed-title">
           {titleFragment}
           {data?.active === false && (
             <Badge>Removal reason: {data?.removalReason}</Badge>
           )}
-        </Stack>
+          <Button
+            variant="secondary"
+            htmlElement="button"
+            type="button"
+            onClick={navigateAway}
+            aria-expanded="false"
+            data-testid="close-button"
+          >
+            <Icon icon="xmark" size="small" />
+            <span>Close</span>
+          </Button>
+        </div>
 
-        <Stack direction="row">
+        <div className="toilet-details-panel__actions">
           {getDirectionsFragment}
           <Button
             htmlElement="button"
@@ -344,18 +355,7 @@ const ToiletDetailsPanel: React.FC<ToiletDetailsPanelProps> = ({
             <Icon icon="list" size="small" />
             <span>Details</span>
           </Button>
-          <Button
-            variant="secondary"
-            htmlElement="button"
-            type="button"
-            onClick={navigateAway}
-            aria-expanded="false"
-            data-testid="close-button"
-          >
-            <Icon icon="xmark" size="small" />
-            <span>Close</span>
-          </Button>
-        </Stack>
+        </div>
       </Center>
     </section>
   );


### PR DESCRIPTION
## What does this change?

On mobile the collapsed toilet details panel wasn't wrapping and things looked bad. This should fix that issue. Super minor change and a cheeky pr before xmas

